### PR TITLE
chore: add new workflow

### DIFF
--- a/.github/workflows/demo-code-standards-fail-version.yml
+++ b/.github/workflows/demo-code-standards-fail-version.yml
@@ -1,0 +1,16 @@
+name: Demo - Code Standards (Fail - Version)
+on:
+  workflow_dispatch:
+jobs:
+  demo-code-standards:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run demo for code standards
+        uses: ./.github/actions/demo-code-standards
+        with:
+          directory: './demo/coding-standards-fail'
+          roslyn-analyzers-version: '4.9.2'
+          

--- a/.github/workflows/demo-code-standards-fail-version.yml
+++ b/.github/workflows/demo-code-standards-fail-version.yml
@@ -13,4 +13,3 @@ jobs:
         with:
           directory: './demo/coding-standards-fail'
           roslyn-analyzers-version: '4.9.2'
-          


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to demonstrate code standards enforcement for a failing demo version. The workflow is triggered manually and runs code standards checks using a specific version of Roslyn analyzers.

**New workflow for code standards demo:**

* Added `.github/workflows/demo-code-standards-fail-version.yml` to define a workflow that runs code standards checks on the `./demo/coding-standards-fail` directory using Roslyn analyzers version `4.9.2`.