### PR TITLE
chore: add various inputs for wider usage

### DIFF
--- a/.github/actions/demo-dotnet-actions/action.yml
+++ b/.github/actions/demo-dotnet-actions/action.yml
@@ -22,7 +22,7 @@ runs:
       if: ${{ inputs.run-build-step == 'true' }}
       uses: ./dotnet/build
       with:   
-          file-to-build: demo/dotnet/src/Api/Api.csproj
+          file-to-build: demo/dotnet/demo.sln
           build-configuration: 'Release'
           dotnet-version: '8.0.x'
           node-version: '18.x'
@@ -31,7 +31,7 @@ runs:
       if: ${{ inputs.run-build-step == 'true' }}
       uses: ./dotnet/build
       with:   
-          file-to-build: demo/dotnet/demo.csproj
+          file-to-build: demo/dotnet/src/Api/Api.csproj
           build-configuration: 'Release'
           dotnet-version: '8.0.x'
           node-version: '18.x'

--- a/.github/actions/demo-dotnet-actions/action.yml
+++ b/.github/actions/demo-dotnet-actions/action.yml
@@ -18,11 +18,20 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Build
+    - name: Build Solution
       if: ${{ inputs.run-build-step == 'true' }}
       uses: ./dotnet/build
       with:   
-          solution-file: demo/dotnet/demo.sln
+          file-to-build: demo/dotnet/src/Api/Api.csproj
+          build-configuration: 'Release'
+          dotnet-version: '8.0.x'
+          node-version: '18.x'
+
+    - name: Build Project
+      if: ${{ inputs.run-build-step == 'true' }}
+      uses: ./dotnet/build
+      with:   
+          file-to-build: demo/dotnet/demo.csproj
           build-configuration: 'Release'
           dotnet-version: '8.0.x'
           node-version: '18.x'
@@ -38,4 +47,3 @@ runs:
     - name: Lint
       if: ${{ inputs.run-lint-step == 'true' }}
       uses: ./dotnet/lint
-

--- a/dotnet/build/action.yml
+++ b/dotnet/build/action.yml
@@ -1,6 +1,18 @@
 name: 'Build Solution'
 description: 'Build solution with .NET and Node.js components'
 inputs:
+  additional-build-args:
+    description: 'Additional arguments for dotnet build command'
+    required: false
+    default: ''
+  additional-pack-args:
+    description: 'Additional arguments for dotnet pack command.  Only applicable if mode is "pack".'
+    required: false
+    default: ''
+  additional-publish-args:
+    description: 'Additional arguments for dotnet publish command.  Only applicable if mode is "publish".'
+    required: false
+    default: ''
   build-configuration:
     description: 'Build configuration (Release/Debug)'
     required: false
@@ -9,6 +21,10 @@ inputs:
     description: '.NET version to use'
     required: false
     default: '6.0.x'
+  mode:
+    description: 'Mode of operation (pack/publish).  Use "pack" when building a NuGet package, "publish" otherwise.'
+    required: false
+    default: 'publish'
   node-version:
     description: 'Node.js version to use'
     required: false
@@ -33,8 +49,8 @@ inputs:
   nuget-usernames:
     description: 'Usernames for source authentication (comma-separated)'
     required: false
-  solution-file:
-    description: 'Path to the solution file (e.g., "Legacy/CrmService/CRM-Service.sln" or "DICE-Server.sln")'
+  file-to-build:
+    description: 'Path to the solution/project file (e.g. "Legacy/CrmService/CRM.Service.csproj" or "DICE-Server.sln")'
     required: true
   upload-artifact-paths:
     description: "Paths to the artifacts to be deployed. If not specified, skips uploading artifacts."
@@ -43,7 +59,7 @@ inputs:
   upload-artifacts-name:
     description: 'Name of the uploaded artifacts. If not specified, defaults to "build-artifacts".  Only applicable if `upload-artifact-paths` is given.'
     required: false
-    default: 'build-artifacts'
+    default: ''
 
 outputs:
   build-artifacts-name:
@@ -79,11 +95,11 @@ runs:
 
     - name: Restore dependencies
       shell: bash
-      run: dotnet restore ${{ inputs.solution-file }}
+      run: dotnet restore ${{ inputs.file-to-build }}
 
-    - name: Build solution
+    - name: Build File
       shell: bash
-      run: dotnet build ${{ inputs.solution-file }} --configuration ${{ inputs.build-configuration }} --no-restore
+      run: dotnet build ${{ inputs.file-to-build }} --configuration ${{ inputs.build-configuration }} --no-restore ${{ inputs.additional-build-args }}
 
     - name: Install npm dependencies
       if: inputs.node-project-path != ''
@@ -97,20 +113,28 @@ runs:
       working-directory: ${{ inputs.node-project-path }}
       run: npm run build
       
-    - name: Publish solution
-      shell: bash
-      run: dotnet publish ${{ inputs.solution-file }} --configuration ${{ inputs.build-configuration }} --no-restore
-
     - name: Set build version
       id: version
       shell: bash
-      run: echo "version=${{ github.run_number }}" >> $GITHUB_OUTPUT
-    
+      run: |
+        echo "version=${{ github.run_number }}" >> $GITHUB_OUTPUT
+        echo "version=${{ github.run_number }}" >> $GITHUB_ENV
+
+    - name: Publish solution
+      if: inputs.mode != 'pack'
+      shell: bash
+      run: dotnet publish ${{ inputs.file-to-build }} --configuration ${{ inputs.build-configuration }} --no-restore ${{ inputs.additional-publish-args }}
+
+    - name: Pack solution
+      if: inputs.mode == 'pack'
+      shell: bash
+      run: dotnet pack ${{ inputs.file-to-build }} --configuration ${{ inputs.build-configuration }} --no-build ${{ inputs.additional-pack-args }}
+      
     - name: Upload build artifacts
-      if: inputs.upload-artifact-paths != ''
+      if: inputs.upload-artifacts-name != ''
       uses: actions/upload-artifact@v4
       id: upload-artifacts
       with:
-        name: ${{ inputs.upload-artifact-paths != '' && inputs.upload-artifacts-name || '' }}
+        name: ${{ inputs.upload-artifacts-name }}
         path: ${{ inputs.upload-artifact-paths }}
         retention-days: 1


### PR DESCRIPTION
This pull request updates the build workflow for .NET and Node.js projects to make it more flexible and configurable. The main improvements include supporting both solution and project file builds, introducing new modes for packing and publishing, and adding options for custom build arguments. These changes make the build process more adaptable to different project structures and deployment requirements.

**Build workflow enhancements:**

* The build workflow now supports building both solution files and individual project files by replacing the `solution-file` input with a more general `file-to-build` input in `dotnet/build/action.yml` and updating its usage in `.github/actions/demo-dotnet-actions/action.yml`. [[1]](diffhunk://#diff-04e1ab3adabf3a9efa1c4fa3310f3b07d4a515abccb2b255b2fa74644061d6e1L36-R53) [[2]](diffhunk://#diff-30e7567c83d74e30a35dd0cce2e25128677411ce9e7acef5b4704998bb3212e7L21-R34) [[3]](diffhunk://#diff-04e1ab3adabf3a9efa1c4fa3310f3b07d4a515abccb2b255b2fa74644061d6e1L82-R102)
* Added a `mode` input to choose between `pack` and `publish` operations, along with corresponding steps for `dotnet pack` and `dotnet publish`, making it easier to build NuGet packages or publish applications as needed. [[1]](diffhunk://#diff-04e1ab3adabf3a9efa1c4fa3310f3b07d4a515abccb2b255b2fa74644061d6e1R24-R27) [[2]](diffhunk://#diff-04e1ab3adabf3a9efa1c4fa3310f3b07d4a515abccb2b255b2fa74644061d6e1R116-R138)

**Configurability improvements:**

* Introduced new inputs (`additional-build-args`, `additional-pack-args`, `additional-publish-args`) to allow passing custom arguments to the respective `dotnet` commands, increasing flexibility for different build scenarios. [[1]](diffhunk://#diff-04e1ab3adabf3a9efa1c4fa3310f3b07d4a515abccb2b255b2fa74644061d6e1R4-R15) [[2]](diffhunk://#diff-04e1ab3adabf3a9efa1c4fa3310f3b07d4a515abccb2b255b2fa74644061d6e1R116-R138)

**Artifact handling changes:**

* Changed artifact upload logic to use `upload-artifacts-name` instead of relying on `upload-artifact-paths`, and set its default to an empty string, ensuring more explicit control over artifact naming and uploading. [[1]](diffhunk://#diff-04e1ab3adabf3a9efa1c4fa3310f3b07d4a515abccb2b255b2fa74644061d6e1L46-R62) [[2]](diffhunk://#diff-04e1ab3adabf3a9efa1c4fa3310f3b07d4a515abccb2b255b2fa74644061d6e1R116-R138)

**Minor workflow updates:**

* Updated step names for clarity (e.g., "Build Solution" and "Build Project") and removed an unnecessary blank line in the lint step. [[1]](diffhunk://#diff-30e7567c83d74e30a35dd0cce2e25128677411ce9e7acef5b4704998bb3212e7L21-R34) [[2]](diffhunk://#diff-30e7567c83d74e30a35dd0cce2e25128677411ce9e7acef5b4704998bb3212e7L41)