### PR TITLE
enhancement(get-changed-files.js): add support for tags and branch-names

### DIFF
--- a/.github/actions/demo-get-changed-files/action.yml
+++ b/.github/actions/demo-get-changed-files/action.yml
@@ -1,0 +1,75 @@
+name: Demo - Get Changed Files
+description: Demonstrates the get-changed-files action with SHA->SHA and tag/branch inputs
+author: Trafera
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare summary and temp repo
+      id: pre
+      shell: bash
+      run: |
+        echo "summary_file=$(pwd)/gcf-summary.txt" >> $GITHUB_OUTPUT
+        echo "repo_dir=$(mktemp -d)" >> $GITHUB_OUTPUT
+
+    - name: Initialize temp git repo with base/head and refs
+      id: init
+      shell: bash
+      working-directory: ${{ steps.pre.outputs.repo_dir }}
+      run: |
+        git init -q
+        git config user.email "ci@example.com"
+        git config user.name "CI Bot"
+        echo "base" > a.txt
+        git add a.txt
+        git commit -q -m "base"
+        base_sha=$(git rev-parse HEAD)
+        git checkout -q -b branch1
+        echo "head" > b.txt
+        git add b.txt
+        git commit -q -m "head"
+        head_sha=$(git rev-parse HEAD)
+        git tag baseTag "$base_sha"
+        echo "base_sha=$base_sha" >> $GITHUB_OUTPUT
+        echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
+
+    - name: Run get-changed-files (SHA -> SHA)
+      id: r1
+      uses: ./get-changed-files
+      with:
+        base-ref: ${{ steps.init.outputs.base_sha }}
+        head-ref: ${{ steps.init.outputs.head_sha }}
+      working-directory: ${{ steps.pre.outputs.repo_dir }}
+
+    - name: Assert (SHA -> SHA)
+      uses: ./testing/assert
+      with:
+        test-name: "changed files between base and head (sha)"
+        summary-file: ${{ steps.pre.outputs.summary_file }}
+        mode: exact
+        expected: '["b.txt"]'
+        actual: ${{ steps.r1.outputs.changed_files }}
+
+    - name: Run get-changed-files (tag -> branch)
+      id: r2
+      uses: ./get-changed-files
+      with:
+        base-ref: baseTag
+        head-ref: branch1
+      working-directory: ${{ steps.pre.outputs.repo_dir }}
+
+    - name: Assert (tag -> branch)
+      uses: ./testing/assert
+      with:
+        test-name: "changed files between tag and branch"
+        summary-file: ${{ steps.pre.outputs.summary_file }}
+        mode: exact
+        expected: '["b.txt"]'
+        actual: ${{ steps.r2.outputs.changed_files }}
+
+    - name: Summarize
+      shell: bash
+      if: always()
+      run: |
+        echo '=== Get Changed Files Demo Summary ===' >> $GITHUB_STEP_SUMMARY
+        cat ${{ steps.pre.outputs.summary_file }} >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/demo-all.yml
+++ b/.github/workflows/demo-all.yml
@@ -46,6 +46,15 @@ jobs:
       - name: Run demo for dotnet actions
         uses: ./.github/actions/demo-dotnet-actions
 
+  demo-get-changed-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run demo for get-changed-files
+        uses: ./.github/actions/demo-get-changed-files
+
   demo-get-project-and-solution-files:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/demo-get-changed-files.yml
+++ b/.github/workflows/demo-get-changed-files.yml
@@ -1,0 +1,13 @@
+name: Demo - Get Changed Files
+on:
+  workflow_dispatch: {}
+
+jobs:
+  demo-get-changed-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run demo for get-changed-files
+        uses: ./.github/actions/demo-get-changed-files

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,3 +1,4 @@
+- add a release worfklow that create a new release from a given tag and other inputs
 - need to test that nuget/nuget-source and any other action that has changed in this branch
   - CodeBits
   - Dice5

--- a/get-changed-files/action.yml
+++ b/get-changed-files/action.yml
@@ -4,11 +4,11 @@ author: 'Trafera'
 
 inputs:
   head-ref:
-    description: 'The head branch of the pull request'
+    description: 'The head branch, tag, or sha.'
     required: false
     default: ${{ github.head_ref }}
   base-ref:
-    description: 'The base branch of the pull request'
+    description: 'The base branch, tag, or sha.'
     required: false
     default: ${{ github.base_ref }}
 

--- a/get-changed-files/get-changed-files.js
+++ b/get-changed-files/get-changed-files.js
@@ -48,22 +48,96 @@ function ensureCommitExists(sha, prNumber) {
     }
 }
 
+// Determine if a string looks like a Git SHA (7 to 40 hex chars)
+function getIsSha(value) {
+    if (!value) return false;
+    const v = String(value).trim();
+    return /^[0-9a-f]{7,40}$/i.test(v);
+}
+
+/**
+ * Resolve a ref (branch name, tag, or SHA) to a commit SHA.
+ * Strategy:
+ * 1) Try `git rev-list -n 1 <ref>` locally (works for branches, tags, and SHAs).
+ * 2) If it fails and we have an origin, try fetching the specific ref from origin then retry (also try origin/<ref>).
+ * 3) As a fallback for SHA-like inputs, verify presence via ensureCommitExists (which may fetch by SHA or PR ref).
+ * Returns empty string if resolution fails.
+ */
+function extractSha(ref, prNumber) {
+    const r = (ref || '').trim();
+    if (!r) return '';
+
+    if (getIsSha(r)) {
+        if (ensureCommitExists(r, prNumber)) return r;
+    }
+
+    const tryRevListRef = (name) => {
+        try {
+            const out = execSync(`git rev-list -n 1 ${name}`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+            return out || '';
+        } catch {
+            return '';
+        }
+    };
+    const tryRevList = () => tryRevListRef(r);
+
+    // First attempt: resolve locally
+    let sha = tryRevList();
+    if (sha) return sha;
+
+    // If not resolvable locally, try to fetch from origin
+    if (hasRemoteOrigin()) {
+        try {
+            // Try fetching the specific ref (works for branches and tags)
+            execSync(`git fetch origin ${r}`, { stdio: 'ignore' });
+        } catch {
+            // If specific fetch failed, try a broader fetch (including tags)
+            try {
+                execSync('git fetch --tags --quiet origin', { stdio: 'ignore' });
+            } catch { }
+        }
+        // Try the provided name first, then origin/<name>
+        sha = tryRevList();
+        if (!sha) sha = tryRevListRef(`origin/${r}`);
+        if (sha) return sha;
+    }
+
+    return '';
+}
+
 function run() {
     try {
         console.log(`🔍 Getting Changed Files between '${process.env.INPUT_BASE_REF}' and '${process.env.INPUT_HEAD_REF}'`);
         console.log('========================================');
 
-        // Use explicit SHAs if provided, fallback to branch names
-        const baseSha = process.env.INPUT_BASE_REF || '';
-        const headSha = process.env.INPUT_HEAD_REF || '';
+        const baseRef = process.env.INPUT_BASE_REF || '';
+        const headRef = process.env.INPUT_HEAD_REF || '';
         const prNumber = process.env.GITHUB_PR_NUMBER || '';
 
+        const baseSha = extractSha(baseRef, prNumber);
+        const headSha = extractSha(headRef, prNumber);
+
+        if (baseRef && !baseSha) {
+            if (getIsSha(baseRef)) {
+                throw new Error(`Base SHA ${baseRef} not found and could not be fetched.`);
+            }
+            throw new Error(`Could not resolve base ref '${baseRef}' to a commit SHA.`);
+        }
+        if (headRef && !headSha) {
+            if (getIsSha(headRef)) {
+                throw new Error(`Head SHA ${headRef} not found and could not be fetched.`);
+            }
+            throw new Error(`Could not resolve head ref '${headRef}' to a commit SHA.`);
+        }
+
+        // Double-check the resolved SHAs exist (and fetch if needed for PR/remote-only SHAs)
         if (baseSha && !ensureCommitExists(baseSha, prNumber)) {
             throw new Error(`Base SHA ${baseSha} not found and could not be fetched.`);
         }
         if (headSha && !ensureCommitExists(headSha, prNumber)) {
             throw new Error(`Head SHA ${headSha} not found and could not be fetched.`);
         }
+
         let gitCommand;
         if (baseSha && headSha) {
             gitCommand = `git diff --name-only ${baseSha}...${headSha}`;
@@ -73,9 +147,7 @@ function run() {
             gitCommand = 'git diff --name-only';
         }
         console.log('Git command:', gitCommand);
-        const files = execSync(gitCommand, {
-            encoding: 'utf8'
-        }).trim();
+        const files = execSync(gitCommand, { encoding: 'utf8' }).trim();
 
         console.log('\n=== Changed Files ===');
         if (files) {
@@ -102,7 +174,6 @@ function run() {
         // Write to GITHUB_OUTPUT
         fs.appendFileSync(process.env.GITHUB_OUTPUT, `changed_files=${json}\n`);
         console.log('✅ Complete - outputs written successfully');
-
     } catch (error) {
         console.error('❌ Error:', error.message);
         process.exit(1);
@@ -113,4 +184,4 @@ if (require.main === module) {
     run();
 }
 
-module.exports = { run, ensureCommitExists };
+module.exports = { run, ensureCommitExists, extractSha };


### PR DESCRIPTION
This pull request enhances the `get-changed-files` GitHub Action to support resolving branch names, tags, or commit SHAs for its input references, instead of only branch names. The main improvement is a new mechanism for robustly resolving these refs to commit SHAs, including local and remote lookup and error handling. Comprehensive tests are added to verify these new capabilities.

### Ref resolution improvements

* Added the `extractSha` function in `get-changed-files.js` to resolve branch names, tags, or SHAs to commit SHAs, including local and remote fetching logic and error handling.
* Updated the main `run()` function to use `extractSha` for both base and head refs, improving reliability and flexibility of changed file detection.

### Input and documentation updates

* Updated the `action.yml` input descriptions to clarify that `head-ref` and `base-ref` can be a branch, tag, or SHA, not just a branch.

### Test suite enhancements

* Added new tests in `get-changed-files.test.js` to verify that `extractSha` resolves local branches, tags, and remote branches, and that `run()` accepts branch and tag inputs.
* Exported `extractSha` for testing purposes. [[1]](diffhunk://#diff-674c3b25ffd980bce6172088cbe14371f739b6eeacca3b2092286ac1d537d19eL116-R187) [[2]](diffhunk://#diff-0b1583073a6f4213de30900f29cecfa600b486b2a9b73452f00601e4092ff5fcL6-R6)

### Minor code cleanups

* Minor formatting and error handling improvements in `get-changed-files.js`. [[1]](diffhunk://#diff-674c3b25ffd980bce6172088cbe14371f739b6eeacca3b2092286ac1d537d19eL76-R150) [[2]](diffhunk://#diff-674c3b25ffd980bce6172088cbe14371f739b6eeacca3b2092286ac1d537d19eL105)