### PR TITLE
chore: add generate-version action

### DIFF
--- a/.github/actions/demo-generate-version/action.yml
+++ b/.github/actions/demo-generate-version/action.yml
@@ -57,9 +57,36 @@ runs:
         infix-value: ${{ inputs.infix }}
         release-keyword: ${{ inputs['release-keyword'] }}
 
+    - name: Run generate-version (releases - initial version)
+      id: rel_initial
+      uses: ./generate-version
+      with:
+        project-file: ${{ steps.pre.outputs.project_file }}
+        infix-value: ${{ inputs.infix }}
+        release-keyword: "initial version"
+
+    - name: Assert version shape (releases - initial version)
+      uses: ./testing/assert
+      with:
+        test-name: "version from releases (initial version) has timestamp"
+        summary-file: ${{ steps.pre.outputs.summary_file }}
+        mode: regex
+        expected: '^\d+\.\d+\.\d+-[A-Za-z0-9]+-\d{12}$'
+        actual: ${{ steps.rel_initial.outputs['version-number'] }}
+
+    - name: Assert base version is 1.0.0 (releases - initial version)
+      uses: ./testing/assert
+      with:
+        test-name: "base version 1.0.0 for initial version keyword"
+        summary-file: ${{ steps.pre.outputs.summary_file }}
+        mode: regex
+        expected: '^1\\.0\\.0-'
+        actual: ${{ steps.rel_initial.outputs['version-number'] }}
+
     - name: Summarize
       if: always()
       shell: bash
       run: |
         echo '=== Generate Version Demo Summary ===' >> $GITHUB_STEP_SUMMARY
         cat ${{ steps.pre.outputs.summary_file }} >> $GITHUB_STEP_SUMMARY
+        echo "Initial version keyword output: ${{ steps.rel_initial.outputs['version-number'] }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/demo-generate-version/action.yml
+++ b/.github/actions/demo-generate-version/action.yml
@@ -1,0 +1,65 @@
+name: Demo - Generate Version
+description: Demonstrates the generate-version action reading csproj or releases and asserts basic shape
+
+author: Trafera
+
+inputs:
+  infix:
+    description: "Optional infix to include between version and timestamp"
+    required: false
+    default: "demo"
+  release-keyword:
+    description: "Optional keyword to search releases; empty to use project file only"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare summary and temp project
+      id: pre
+      shell: bash
+      run: |
+        echo "summary_file=$(pwd)/gv-summary.txt" >> $GITHUB_OUTPUT
+        mkdir -p _gv
+        cat > _gv/Demo.App.csproj <<'EOF'
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net8.0</TargetFramework>
+            <Version>2.3.4-beta</Version>
+          </PropertyGroup>
+        </Project>
+        EOF
+        echo "project_file=$(pwd)/_gv/Demo.App.csproj" >> $GITHUB_OUTPUT
+
+    - name: Run generate-version (csproj)
+      id: csproj
+      uses: ./generate-version
+      with:
+        project-file: ${{ steps.pre.outputs.project_file }}
+        infix-value: ${{ inputs.infix }}
+
+    - name: Assert version shape (csproj)
+      uses: ./testing/assert
+      with:
+        test-name: "version from csproj has timestamp"
+        summary-file: ${{ steps.pre.outputs.summary_file }}
+        mode: regex
+        expected: '^\d+\.\d+\.\d+-[A-Za-z0-9]+-\d{12}$'
+        actual: ${{ steps.csproj.outputs['version-number'] }}
+
+    - name: Run generate-version (releases)
+      id: rel
+      if: ${{ inputs['release-keyword'] != '' }}
+      uses: ./generate-version
+      with:
+        project-file: ${{ steps.pre.outputs.project_file }}
+        infix-value: ${{ inputs.infix }}
+        release-keyword: ${{ inputs['release-keyword'] }}
+
+    - name: Summarize
+      if: always()
+      shell: bash
+      run: |
+        echo '=== Generate Version Demo Summary ===' >> $GITHUB_STEP_SUMMARY
+        cat ${{ steps.pre.outputs.summary_file }} >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/demo-all.yml
+++ b/.github/workflows/demo-all.yml
@@ -45,6 +45,15 @@ jobs:
 
       - name: Run demo for dotnet actions
         uses: ./.github/actions/demo-dotnet-actions
+        
+  demo-generate-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run demo for generate-version
+        uses: ./.github/actions/demo-generate-version
 
   demo-get-changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/demo-generate-version.yml
+++ b/.github/workflows/demo-generate-version.yml
@@ -1,0 +1,65 @@
+name: Demo - Generate Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      infix:
+        description: 'Optional infix (e.g., beta, rc)'
+        required: false
+        type: string
+        default: demo
+      release-keyword:
+        description: 'Optional keyword to search releases (leave empty to use project file)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create demo project file
+        id: make_csproj
+        shell: bash
+        run: |
+          demo_dir="${{ github.workspace }}/_demo"
+          mkdir -p "$demo_dir"
+          cat > "$demo_dir/Demo.App.csproj" <<'EOF'
+          <Project Sdk="Microsoft.NET.Sdk">
+            <PropertyGroup>
+              <TargetFramework>net8.0</TargetFramework>
+              <Version>1.2.3-alpha</Version>
+            </PropertyGroup>
+          </Project>
+          EOF
+          echo "project_file=$demo_dir/Demo.App.csproj" >> "$GITHUB_OUTPUT"
+
+      - name: Run generate-version (project-file path)
+        id: gen_from_csproj
+        uses: ./generate-version
+        with:
+          project-file: ${{ steps.make_csproj.outputs.project_file }}
+          infix-value: ${{ github.event.inputs.infix }}
+
+      - name: Run generate-version (release-keyword, if provided)
+        id: gen_from_releases
+        if: ${{ github.event.inputs['release-keyword'] != '' }}
+        uses: ./generate-version
+        with:
+          project-file: ${{ steps.make_csproj.outputs.project_file }}
+          infix-value: ${{ github.event.inputs.infix }}
+          release-keyword: ${{ github.event.inputs['release-keyword'] }}
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          echo '=== Generate Version Demo ===' >> "$GITHUB_STEP_SUMMARY"
+          echo "Project file: ${{ steps.make_csproj.outputs.project_file }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "From csproj: ${{ steps.gen_from_csproj.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${{ github.event.inputs['release-keyword'] }}" ]; then
+            echo "From releases: ${{ steps.gen_from_releases.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/generate-version/action.yml
+++ b/generate-version/action.yml
@@ -1,0 +1,37 @@
+name: "Generate Version"
+description: "Generates a version number based on whether there is a release in the existing repo that matches a keyword.  If not, it will look in the given .csproj file for the current version"
+author: "Trafera"
+
+inputs:
+  infix-value:
+    description: 'Infix value insert between the version number and the date timestamp (e.g., "beta", "alpha", "rc")'
+    required: false
+    default: ""
+  project-file:
+    description: "Path to the .csproj file for the project being released"
+    required: true
+  release-keyword:
+    description: "Keyword used to look for release version"
+    required: false
+    default: ""
+
+outputs:
+  version-number:
+    description: "Generated version number"
+    value: ${{ steps.calc_version.outputs.version_number }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node.js
+      uses: Now-Micro/actions/setup-node@v1
+
+    - name: Calculate version
+      id: calc_version
+      shell: bash
+      run: node "$GITHUB_ACTION_PATH/generate-version.js"
+      env:
+        INPUT_INFIX_VALUE: ${{ inputs.infix-value }}
+        INPUT_PROJECT_FILE: ${{ inputs.project-file }}
+        INPUT_RELEASE_KEYWORD: ${{ inputs['release-keyword'] }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/generate-version/generate-version.js
+++ b/generate-version/generate-version.js
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+function exitWith(msg) {
+    console.error(`❌ ${msg}`);
+    process.exit(1);
+}
+
+function isSemVer(v) {
+    return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/.test(v);
+}
+
+function toBaseSemVer(v) {
+    if (!v) return '';
+    // Trim CRLF/whitespace
+    v = String(v).replace(/\r/g, '').trim();
+    // If four-part like 1.2.3.4, reduce to 1.2.3
+    const m4 = v.match(/^(\d+\.\d+\.\d+)\.(\d+)$/);
+    if (m4) v = m4[1];
+    // Strip pre-release suffix if present
+    v = v.replace(/-.*/, '');
+    if (!/^\d+\.\d+\.\d+$/.test(v)) return '';
+    return v;
+}
+
+function readCsprojVersion(file) {
+    const xml = fs.readFileSync(file, 'utf8');
+    const mVer = xml.match(/<Version>([^<]+)<\/Version>/);
+    if (mVer) return toBaseSemVer(mVer[1]);
+    const mPrefix = xml.match(/<VersionPrefix>([^<]+)<\/VersionPrefix>/);
+    if (mPrefix) return toBaseSemVer(mPrefix[1]);
+    return '1.0.0';
+}
+
+function ghRequest(pathname, token) {
+    const opts = {
+        hostname: 'api.github.com',
+        method: 'GET',
+        path: pathname,
+        headers: {
+            'User-Agent': 'now-micro-actions/version-generator',
+            'Accept': 'application/vnd.github+json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+    };
+    return new Promise((resolve, reject) => {
+        const req = https.request(opts, res => {
+            let buf = '';
+            res.on('data', d => (buf += d));
+            res.on('end', () => {
+                if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+                    try { resolve(JSON.parse(buf)); } catch { resolve({}); }
+                } else if (res.statusCode === 404) {
+                    resolve(null);
+                } else {
+                    reject(new Error(`GitHub API ${res.statusCode}: ${buf}`));
+                }
+            });
+        });
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+async function findReleaseVersionByKeyword(owner, repo, keyword, token) {
+    // List latest 100 releases and find the first matching keyword
+    const data = await ghRequest(`/repos/${owner}/${repo}/releases?per_page=100`, token);
+    if (!Array.isArray(data)) return '';
+    const re = new RegExp(keyword, 'i');
+    for (const r of data) {
+        const name = r.name || r.tag_name || '';
+        if (re.test(name)) {
+            // Prefer tag_name as semver source
+            const candidate = String(r.tag_name || '').trim() || String(r.name || '').trim();
+            const base = toBaseSemVer(candidate);
+            if (base) return base;
+        }
+    }
+    return '';
+}
+
+async function run() {
+    console.log('🔧 Starting version generation');
+    const projectFile = process.env.INPUT_PROJECT_FILE;
+    const infix = (process.env.INPUT_INFIX_VALUE || '').trim();
+    const releaseKeyword = (process.env.INPUT_RELEASE_KEYWORD || '').trim();
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
+    console.log(`🔍 Inputs: projectFile=${projectFile || '(none)'} infix=${infix || '(none)'} releaseKeyword=${releaseKeyword || '(none)'} `);
+
+    if (!projectFile && !releaseKeyword) {
+        exitWith('INPUT_PROJECT_FILE is required when release-keyword is not provided');
+    }
+
+    let baseVersion = '';
+
+    if (releaseKeyword) {
+        const repoFull = process.env.GITHUB_REPOSITORY || '';
+        const [owner, repo] = repoFull.split('/');
+        if (!owner || !repo) exitWith('GITHUB_REPOSITORY not set');
+        try {
+            console.log(`🔎 Searching releases in ${owner}/${repo} for keyword: ${releaseKeyword}`);
+            baseVersion = await findReleaseVersionByKeyword(owner, repo, releaseKeyword, token);
+            if (baseVersion) {
+                console.log(`📦 Found release base version: ${baseVersion}`);
+            } else {
+                console.log('ℹ️ No matching release found, will fall back to project file if provided.');
+            }
+        } catch (e) {
+            exitWith(`Failed to query releases: ${e.message}`);
+        }
+    }
+
+    if (!baseVersion) {
+        if (!projectFile) exitWith('INPUT_PROJECT_FILE is required to read version from csproj');
+        const abs = path.isAbsolute(projectFile) ? projectFile : path.join(process.cwd(), projectFile);
+        if (!fs.existsSync(abs)) exitWith(`Project file not found: ${abs}`);
+        try {
+            console.log(`📄 Reading version from project file: ${abs}`);
+            baseVersion = readCsprojVersion(abs);
+            console.log(`📌 Project file base version: ${baseVersion || '(empty)'}`);
+        } catch (e) {
+            exitWith(`Failed to read project file: ${e.message}`);
+        }
+    }
+
+    if (!/^\d+\.\d+\.\d+$/.test(baseVersion)) {
+        exitWith(`Invalid semantic base version: ${baseVersion}`);
+    }
+
+    // Build final version: versionNumber-infix-timestamp
+    const ts = new Date();
+    const pad = n => String(n).padStart(2, '0');
+    const timestamp = `${ts.getUTCFullYear()}${pad(ts.getUTCMonth() + 1)}${pad(ts.getUTCDate())}${pad(ts.getUTCHours())}${pad(ts.getUTCMinutes())}`;
+    const parts = [baseVersion];
+    if (infix) parts.push(infix);
+    parts.push(timestamp);
+    const version = parts.join('-');
+
+    // Output
+    const out = process.env.GITHUB_OUTPUT;
+    if (!out) exitWith('GITHUB_OUTPUT not set');
+    fs.appendFileSync(out, `version_number=${version}\n`);
+    console.log(`✅ Version: ${version}`);
+}
+
+if (require.main === module) {
+    run().catch(e => exitWith(e.message));
+}
+
+module.exports = { run, isSemVer, toBaseSemVer };

--- a/generate-version/generate-version.js
+++ b/generate-version/generate-version.js
@@ -31,7 +31,7 @@ function readCsprojVersion(file) {
     if (mVer) return toBaseSemVer(mVer[1]);
     const mPrefix = xml.match(/<VersionPrefix>([^<]+)<\/VersionPrefix>/);
     if (mPrefix) return toBaseSemVer(mPrefix[1]);
-    return '1.0.0';
+    return '0.0.1';
 }
 
 function ghRequest(pathname, token) {

--- a/generate-version/generate-version.test.js
+++ b/generate-version/generate-version.test.js
@@ -104,6 +104,19 @@ test('queries releases and finds matching by keyword (tag_name)', async () => {
     restoreDate();
 });
 
+test("queries releases and finds 'initial version' keyword (case-insensitive)", async () => {
+    const restoreDate = mockDate('2024-02-01T00:00:00Z');
+    const restoreHttps = mockHttpsOnce(200, [
+        { name: 'Initial Version', tag_name: '1.0.0' },
+        { name: 'Other', tag_name: '0.9.0' }
+    ]);
+    const r = await runWith({ INPUT_RELEASE_KEYWORD: 'initial version', INPUT_INFIX_VALUE: 'demo' });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=1.0.0-demo-202402010000/);
+    restoreHttps();
+    restoreDate();
+});
+
 test('queries releases but no match, falls back to csproj', async () => {
     const restoreDate = mockDate('2024-01-02T03:04:00Z');
     const restoreHttps = mockHttpsOnce(200, [{ name: 'Other', tag_name: '0.1.0' }]);
@@ -135,7 +148,7 @@ test('uses default 1.0.0 when no version tags in csproj', async () => {
     fs.writeFileSync(csproj, '<Project><PropertyGroup></PropertyGroup></Project>');
     const r = await runWith({ INPUT_PROJECT_FILE: csproj });
     assert.strictEqual(r.exitCode, 0);
-    assert.match(r.outputContent, /version_number=1.0.0-202502030405/);
+    assert.match(r.outputContent, /version_number=0.0.1-202502030405/);
     restoreDate();
 });
 

--- a/generate-version/generate-version.test.js
+++ b/generate-version/generate-version.test.js
@@ -1,0 +1,200 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const https = require('https');
+
+const { run, isSemVer, toBaseSemVer } = require('./generate-version');
+
+async function withEnvAsync(env, fn) {
+    const prev = { ...process.env };
+    Object.assign(process.env, env);
+    let exitCode = 0;
+    const origExit = process.exit;
+    process.exit = c => { exitCode = c || 0; throw new Error(`__EXIT_${exitCode}__`); };
+    let out = '', err = '';
+    const so = process.stdout.write, se = process.stderr.write;
+    process.stdout.write = (c, e, cb) => { out += c; return true; };
+    process.stderr.write = (c, e, cb) => { err += c; return true; };
+    try {
+        try { await fn(); } catch (e) { if (!/^__EXIT_/.test(e.message)) throw e; }
+    } finally {
+        process.env = prev;
+        process.exit = origExit;
+        process.stdout.write = so;
+        process.stderr.write = se;
+    }
+    return { exitCode, out, err };
+}
+
+async function runWith(env, githubRepo = 'owner/repo') {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gv-'));
+    const outFile = path.join(dir, 'out.txt');
+    fs.writeFileSync(outFile, '');
+    const r = await withEnvAsync({ ...env, GITHUB_OUTPUT: outFile, GITHUB_REPOSITORY: githubRepo }, () => run());
+    r.outputFile = outFile;
+    r.outputContent = fs.readFileSync(outFile, 'utf8');
+    return r;
+}
+
+function mockHttpsOnce(statusCode, body) {
+    const orig = https.request;
+    https.request = (opts, cb) => {
+        const events = {};
+        const res = { statusCode, on: (ev, fn) => { events[ev] = fn; }, headers: {} };
+        process.nextTick(() => {
+            cb(res);
+            if (events['data']) events['data'](typeof body === 'string' ? body : JSON.stringify(body))
+            if (events['end']) events['end']();
+        });
+        return { on: () => { }, end: () => { }, write: () => { } };
+    };
+    return () => { https.request = orig; };
+}
+
+// Helpers for deterministic timestamp
+function mockDate(iso) {
+    const RealDate = Date;
+    // month is 0-based in JS Date
+    const d = new Date(iso);
+    global.Date = class extends RealDate {
+        constructor(...args) {
+            if (args.length) return new RealDate(...args);
+            return d;
+        }
+        static now() { return d.getTime(); }
+        static UTC(...args) { return RealDate.UTC(...args); }
+        static parse(s) { return RealDate.parse(s); }
+    };
+    return () => { global.Date = RealDate; };
+}
+
+// Unit tests
+
+test('isSemVer true/false', () => {
+    assert.strictEqual(isSemVer('1.2.3'), true);
+    assert.strictEqual(isSemVer('1.2.3-alpha.1'), true);
+    assert.strictEqual(isSemVer('1.2'), false);
+});
+
+test('toBaseSemVer trims, reduces, strips prerelease', () => {
+    assert.strictEqual(toBaseSemVer(' 1.2.3\r '), '1.2.3');
+    assert.strictEqual(toBaseSemVer('1.2.3.4'), '1.2.3');
+    assert.strictEqual(toBaseSemVer('1.2.3-alpha.1'), '1.2.3');
+    assert.strictEqual(toBaseSemVer('bad'), '');
+});
+
+test('fails when neither project-file nor release-keyword provided', async () => {
+    const r = await runWith({ INPUT_PROJECT_FILE: '', INPUT_RELEASE_KEYWORD: '' });
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /required when release-keyword/);
+});
+
+test('queries releases and finds matching by keyword (tag_name)', async () => {
+    const restoreDate = mockDate('2024-10-10T12:34:00Z');
+    const restoreHttps = mockHttpsOnce(200, [
+        { name: 'Unrelated', tag_name: '0.9.0' },
+        { name: 'Important', tag_name: '1.2.3' }
+    ]);
+    const r = await runWith({ INPUT_RELEASE_KEYWORD: 'Important', INPUT_INFIX_VALUE: 'beta' });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=1.2.3-beta-202410101234/);
+    restoreHttps();
+    restoreDate();
+});
+
+test('queries releases but no match, falls back to csproj', async () => {
+    const restoreDate = mockDate('2024-01-02T03:04:00Z');
+    const restoreHttps = mockHttpsOnce(200, [{ name: 'Other', tag_name: '0.1.0' }]);
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gvp-'));
+    const csproj = path.join(dir, 'App.csproj');
+    fs.writeFileSync(csproj, '<Project><PropertyGroup><Version>2.3.4-alpha</Version></PropertyGroup></Project>');
+    const r = await runWith({ INPUT_RELEASE_KEYWORD: 'Missing', INPUT_PROJECT_FILE: csproj, INPUT_INFIX_VALUE: 'rc' });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=2.3.4-rc-202401020304/);
+    restoreHttps();
+    restoreDate();
+});
+
+test('reads version from csproj when keyword omitted', async () => {
+    const restoreDate = mockDate('2023-12-31T23:59:00Z');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gvc-'));
+    const csproj = path.join(dir, 'Lib.csproj');
+    fs.writeFileSync(csproj, '<Project><PropertyGroup><VersionPrefix>3.4.5.6</VersionPrefix></PropertyGroup></Project>');
+    const r = await runWith({ INPUT_PROJECT_FILE: csproj, INPUT_INFIX_VALUE: '' });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=3.4.5-202312312359/);
+    restoreDate();
+});
+
+test('uses default 1.0.0 when no version tags in csproj', async () => {
+    const restoreDate = mockDate('2025-02-03T04:05:00Z');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gvd-'));
+    const csproj = path.join(dir, 'NoVer.csproj');
+    fs.writeFileSync(csproj, '<Project><PropertyGroup></PropertyGroup></Project>');
+    const r = await runWith({ INPUT_PROJECT_FILE: csproj });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=1.0.0-202502030405/);
+    restoreDate();
+});
+
+test('errors on invalid semver in project file', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gve-'));
+    const csproj = path.join(dir, 'Bad.csproj');
+    fs.writeFileSync(csproj, '<Project><PropertyGroup><Version>bad.version</Version></PropertyGroup></Project>');
+    const r = await runWith({ INPUT_PROJECT_FILE: csproj });
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /Invalid semantic base version/);
+});
+
+test('errors when project file missing', async () => {
+    const r = await runWith({ INPUT_PROJECT_FILE: 'missing.csproj' });
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /Project file not found/);
+});
+
+test('propagates GitHub API error', async () => {
+    const restoreHttps = mockHttpsOnce(500, { message: 'boom' });
+    const r = await runWith({ INPUT_RELEASE_KEYWORD: 'kw' });
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /Failed to query releases/);
+    restoreHttps();
+});
+
+test('404 from releases API treated as no match, fall back to csproj', async () => {
+    const restoreDate = mockDate('2024-06-07T08:09:00Z');
+    const restoreHttps = mockHttpsOnce(404, {});
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gvf-'));
+    const csproj = path.join(dir, 'Fallback.csproj');
+    fs.writeFileSync(csproj, '<Project><PropertyGroup><Version>9.8.7</Version></PropertyGroup></Project>');
+    const r = await runWith({ INPUT_RELEASE_KEYWORD: 'kw', INPUT_PROJECT_FILE: csproj });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=9.8.7-202406070809/);
+    restoreHttps();
+    restoreDate();
+});
+
+test('errors when GITHUB_OUTPUT is not set at write time', async () => {
+    // Use withEnvAsync directly to omit GITHUB_OUTPUT
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gvo-'));
+    const csproj = path.join(dir, 'App.csproj');
+    fs.writeFileSync(csproj, '<Project><PropertyGroup><Version>1.2.3</Version></PropertyGroup></Project>');
+    const r = await (async () => {
+        const prev = { ...process.env };
+        Object.assign(process.env, { INPUT_PROJECT_FILE: csproj, GITHUB_REPOSITORY: 'owner/repo' });
+        let exitCode = 0; const origExit = process.exit; process.exit = c => { exitCode = c || 0; throw new Error(`__EXIT_${exitCode}__`); };
+        let out = '', err = ''; const so = process.stdout.write, se = process.stderr.write;
+        process.stdout.write = (c, e, cb) => { out += c; return true; }; process.stderr.write = (c, e, cb) => { err += c; return true; };
+        try { try { await run(); } catch (e) { if (!/^__EXIT_/.test(e.message)) throw e; } } finally { process.env = prev; process.exit = origExit; process.stdout.write = so; process.stderr.write = se; }
+        return { exitCode, out, err };
+    })();
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /GITHUB_OUTPUT not set/);
+});
+
+test('errors when release-keyword present but GITHUB_REPOSITORY missing', async () => {
+    const r = await withEnvAsync({ INPUT_RELEASE_KEYWORD: 'kw', GITHUB_OUTPUT: path.join(os.tmpdir(), 'out.txt'), GITHUB_REPOSITORY: '' }, () => run());
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /GITHUB_REPOSITORY not set/);
+});


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Action and supporting workflow for generating version numbers based on `.csproj` files or GitHub releases, along with comprehensive automated tests to validate its behavior. The main themes are the creation of the action, its integration into demo workflows, and thorough testing.

**New GitHub Action: Generate Version**
* Added a new composite action in `generate-version/action.yml` that generates a semantic version number using either a `.csproj` file or by searching for a release keyword in GitHub releases. Outputs a version string in the format `major.minor.patch-infix-timestamp`.
* Implemented the core logic in `generate-version/generate-version.js`, including semantic version parsing, release lookup via GitHub API, fallback to project file, and output handling.

**Demo and Workflow Integration**
* Created `.github/actions/demo-generate-version/action.yml` to demonstrate and assert the behavior of the new action, including tests for both project file and release keyword scenarios.
* Added a dedicated workflow `.github/workflows/demo-generate-version.yml` for manual testing and demonstration of the version generation action with user inputs.
* Integrated the demo action into the main workflow `.github/workflows/demo-all.yml` for continuous validation.

**Automated Testing**
* Added `generate-version/generate-version.test.js` with extensive unit and integration tests covering semantic version parsing, release lookup, fallback logic, error handling, and output formatting.