### PR TITLE
fix(generate-version): issues

### DIFF
--- a/.github/actions/demo-generate-version/action.yml
+++ b/.github/actions/demo-generate-version/action.yml
@@ -20,7 +20,9 @@ runs:
       id: pre
       shell: bash
       run: |
-        echo "summary_file=$(pwd)/gv-summary.txt" >> $GITHUB_OUTPUT
+        echo "summary_file=$(pwd)/gv-summary.txt" >> "$GITHUB_OUTPUT"
+        # ensure summary file exists to avoid cat errors if earlier steps fail
+        touch "$(pwd)/gv-summary.txt"
         mkdir -p _gv
         cat > _gv/Demo.App.csproj <<'EOF'
         <Project Sdk="Microsoft.NET.Sdk">
@@ -30,7 +32,7 @@ runs:
           </PropertyGroup>
         </Project>
         EOF
-        echo "project_file=$(pwd)/_gv/Demo.App.csproj" >> $GITHUB_OUTPUT
+        echo "project_file=$(pwd)/_gv/Demo.App.csproj" >> "$GITHUB_OUTPUT"
 
     - name: Run generate-version (csproj)
       id: csproj
@@ -87,6 +89,12 @@ runs:
       if: always()
       shell: bash
       run: |
-        echo '=== Generate Version Demo Summary ===' >> $GITHUB_STEP_SUMMARY
-        cat ${{ steps.pre.outputs.summary_file }} >> $GITHUB_STEP_SUMMARY
-        echo "Initial version keyword output: ${{ steps.rel_initial.outputs['version-number'] }}" >> $GITHUB_STEP_SUMMARY
+        echo '=== Generate Version Demo Summary ===' >> "$GITHUB_STEP_SUMMARY"
+        if [ -f "${{ steps.pre.outputs.summary_file }}" ]; then
+          cat "${{ steps.pre.outputs.summary_file }}" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "(no per-step summary file present)" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        if [ -n "${{ steps.rel_initial.outputs['version-number'] }}" ]; then
+          echo "Initial version keyword output: ${{ steps.rel_initial.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/.github/workflows/run-workflow-tests.yml
+++ b/.github/workflows/run-workflow-tests.yml
@@ -21,4 +21,4 @@ jobs:
           echo "Running Node tests in with coverage"
           node --version
           # Generates text and lcov coverage reports
-          npx --yes c8 -r text -r lcov node --test
+          npx --yes c8 -r text -r lcov node --test --test-reporter=spec

--- a/generate-version/action.yml
+++ b/generate-version/action.yml
@@ -34,4 +34,3 @@ runs:
         INPUT_INFIX_VALUE: ${{ inputs.infix-value }}
         INPUT_PROJECT_FILE: ${{ inputs.project-file }}
         INPUT_RELEASE_KEYWORD: ${{ inputs['release-keyword'] }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/generate-version/generate-version.js
+++ b/generate-version/generate-version.js
@@ -67,8 +67,11 @@ function ghRequest(pathname, token) {
 async function findReleaseVersionByKeyword(owner, repo, keyword, token) {
     // List latest 100 releases and find the first matching keyword
     const data = await ghRequest(`/repos/${owner}/${repo}/releases?per_page=100`, token);
+
+    console.log(`🔎 Found ${Array.isArray(data) ? data.length : 0} releases from GitHub API`);
+    console.log({ data });
     if (!Array.isArray(data)) return '';
-    const re = new RegExp(keyword, 'i');
+    const re = new RegExp(keyword, 'ig');
     for (const r of data) {
         const name = r.name || r.tag_name || '';
         if (re.test(name)) {

--- a/generate-version/generate-version.js
+++ b/generate-version/generate-version.js
@@ -65,18 +65,26 @@ function ghRequest(pathname, token) {
 }
 
 async function findReleaseVersionByKeyword(owner, repo, keyword, token) {
-    // List latest 100 releases and find the first matching keyword
+    // List latest 100 releases and find the first matching keyword in name or body
     const data = await ghRequest(`/repos/${owner}/${repo}/releases?per_page=100`, token);
 
     console.log(`🔎 Found ${Array.isArray(data) ? data.length : 0} releases from GitHub API`);
     console.log({ data });
     if (!Array.isArray(data)) return '';
-    const re = new RegExp(keyword, 'ig');
+    const re = new RegExp(keyword, 'i');
     for (const r of data) {
-        const name = r.name || r.tag_name || '';
-        if (re.test(name)) {
-            // Prefer tag_name as semver source
-            const candidate = String(r.tag_name || '').trim() || String(r.name || '').trim();
+        const name = String(r.name || '');
+        const body = String(r.body || '');
+        if (re.test(name) || re.test(body)) {
+            // Extract a semantic version from the name, if present
+            const m = name.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/);
+            if (m) {
+                console.log(`Found matching release: ${name} (${m[0]})`);
+                const fromName = toBaseSemVer(m[0]);
+                if (fromName) return fromName;
+            }
+            // Fallback: try tag_name or the entire name as a candidate
+            const candidate = String(r.tag_name || '').trim() || name.trim();
             const base = toBaseSemVer(candidate);
             if (base) return base;
         }

--- a/generate-version/generate-version.test.js
+++ b/generate-version/generate-version.test.js
@@ -104,6 +104,18 @@ test('queries releases and finds matching by keyword (tag_name)', async () => {
     restoreDate();
 });
 
+test('matches keyword in body and extracts semver from name', async () => {
+    const restoreDate = mockDate('2024-03-04T05:06:00Z');
+    const restoreHttps = mockHttpsOnce(200, [
+        { name: 'Release 2.1.0', body: 'Includes Special Feature' }
+    ]);
+    const r = await runWith({ INPUT_RELEASE_KEYWORD: 'special feature', INPUT_INFIX_VALUE: 'beta' });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=2.1.0-beta-202403040506/);
+    restoreHttps();
+    restoreDate();
+});
+
 test("queries releases and finds 'initial version' keyword (case-insensitive)", async () => {
     const restoreDate = mockDate('2024-02-01T00:00:00Z');
     const restoreHttps = mockHttpsOnce(200, [

--- a/generate-version/generate-version.test.js
+++ b/generate-version/generate-version.test.js
@@ -208,6 +208,8 @@ test('errors when GITHUB_OUTPUT is not set at write time', async () => {
     const r = await (async () => {
         const prev = { ...process.env };
         Object.assign(process.env, { INPUT_PROJECT_FILE: csproj, GITHUB_REPOSITORY: 'owner/repo' });
+        // Ensure GITHUB_OUTPUT is truly absent even on GitHub runners
+        delete process.env.GITHUB_OUTPUT;
         let exitCode = 0; const origExit = process.exit; process.exit = c => { exitCode = c || 0; throw new Error(`__EXIT_${exitCode}__`); };
         let out = '', err = ''; const so = process.stdout.write, se = process.stderr.write;
         process.stdout.write = (c, e, cb) => { out += c; return true; }; process.stderr.write = (c, e, cb) => { err += c; return true; };


### PR DESCRIPTION
This pull request introduces improvements to the version generation demo workflow and enhances the robustness of the release version detection logic. The changes mainly focus on making the GitHub Actions workflow more reliable and improving the semantic version extraction from releases, including better keyword matching and error handling.

**Workflow reliability and error handling:**

* Ensured the summary file in `.github/actions/demo-generate-version/action.yml` is always created before use to prevent errors when earlier steps fail, and improved handling of missing summary files in the final summary step. [[1]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L23-R25) [[2]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L90-R100)
* Updated echo commands to consistently quote output file variables for safer shell execution. [[1]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L23-R25) [[2]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L33-R35)

**Release version detection improvements:**

* Enhanced the logic in `generate-version/generate-version.js` to match the keyword in both the release name and body, and to extract semantic version numbers directly from the release name when present. Added debug logging for release detection.
* Added a new test case in `generate-version/generate-version.test.js` to verify matching the keyword in the release body and extracting the semver from the name.

**Test and workflow enhancements:**

* Modified the Node test command in `.github/workflows/run-workflow-tests.yml` to use the `spec` test reporter for improved output readability.
* Improved test reliability by ensuring the `GITHUB_OUTPUT` environment variable is properly unset in relevant test cases.