### PR TITLE
chore: add logs

### DIFF
--- a/generate-version/generate-version.js
+++ b/generate-version/generate-version.js
@@ -75,9 +75,11 @@ async function findReleaseVersionByKeyword(owner, repo, keyword, token) {
     for (const r of data) {
         const name = String(r.name || '');
         const body = String(r.body || '');
+        console.log({ name, body });
         if (re.test(name) || re.test(body)) {
             // Extract a semantic version from the name, if present
             const m = name.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/);
+            console.log({ m });
             if (m) {
                 console.log(`Found matching release: ${name} (${m[0]})`);
                 const fromName = toBaseSemVer(m[0]);


### PR DESCRIPTION
This pull request adds some debugging output to the release version search logic. The main change is the addition of logging statements to help trace the values being processed when searching for a release version by keyword.

Debugging and logging improvements:

* Added `console.log` statements to output the `name` and `body` of each release, as well as the result of the semantic version match (`m`), in the `findReleaseVersionByKeyword` function in `generate-version/generate-version.js`.