### PR TITLE
chore(generate-version): add increment-type input

### DIFF
--- a/.github/actions/demo-generate-version/action.yml
+++ b/.github/actions/demo-generate-version/action.yml
@@ -50,6 +50,15 @@ runs:
         expected: '^\d+\.\d+\.\d+-[A-Za-z0-9]+-\d{12}$'
         actual: ${{ steps.csproj.outputs['version-number'] }}
 
+    - name: Assert default patch bump (csproj)
+      uses: ./testing/assert
+      with:
+        test-name: "default patch bump from 2.3.4 -> 2.3.5"
+        summary-file: ${{ steps.pre.outputs.summary_file }}
+        mode: regex
+        expected: '^2\.3\.5-'
+        actual: ${{ steps.csproj.outputs['version-number'] }}
+
     - name: Run generate-version (releases)
       id: rel
       if: ${{ inputs['release-keyword'] != '' }}
@@ -79,11 +88,45 @@ runs:
     - name: Assert base version is 1.0.0 (releases - initial version)
       uses: ./testing/assert
       with:
-        test-name: "base version 1.0.0 for initial version keyword"
+        test-name: "base version 1.0.1 for initial version keyword (patch bump)"
         summary-file: ${{ steps.pre.outputs.summary_file }}
         mode: regex
-        expected: '^1\\.0\\.0-'
+        expected: '^1\\.0\\.1-'
         actual: ${{ steps.rel_initial.outputs['version-number'] }}
+
+    - name: Run generate-version (csproj - minor bump)
+      id: csproj_minor
+      uses: ./generate-version
+      with:
+        project-file: ${{ steps.pre.outputs.project_file }}
+        infix-value: ${{ inputs.infix }}
+        increment-type: minor
+
+    - name: Assert minor bump (csproj)
+      uses: ./testing/assert
+      with:
+        test-name: "minor bump from 2.3.4 -> 2.4.0"
+        summary-file: ${{ steps.pre.outputs.summary_file }}
+        mode: regex
+        expected: '^2\\.4\\.0-'
+        actual: ${{ steps.csproj_minor.outputs['version-number'] }}
+
+    - name: Run generate-version (csproj - major bump)
+      id: csproj_major
+      uses: ./generate-version
+      with:
+        project-file: ${{ steps.pre.outputs.project_file }}
+        infix-value: ${{ inputs.infix }}
+        increment-type: major
+
+    - name: Assert major bump (csproj)
+      uses: ./testing/assert
+      with:
+        test-name: "major bump from 2.3.4 -> 3.0.0"
+        summary-file: ${{ steps.pre.outputs.summary_file }}
+        mode: regex
+        expected: '^3\\.0\\.0-'
+        actual: ${{ steps.csproj_major.outputs['version-number'] }}
 
     - name: Summarize
       if: always()
@@ -94,6 +137,19 @@ runs:
           cat "${{ steps.pre.outputs.summary_file }}" >> "$GITHUB_STEP_SUMMARY"
         else
           echo "(no per-step summary file present)" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        # Include key outputs for quick reference
+        if [ -n "${{ steps.csproj.outputs['version-number'] }}" ]; then
+          echo "Csproj (default patch): ${{ steps.csproj.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        if [ -n "${{ steps.csproj_minor.outputs['version-number'] }}" ]; then
+          echo "Csproj (minor bump): ${{ steps.csproj_minor.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        if [ -n "${{ steps.csproj_major.outputs['version-number'] }}" ]; then
+          echo "Csproj (major bump): ${{ steps.csproj_major.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
+        fi
+        if [ -n "${{ steps.rel.outputs['version-number'] }}" ]; then
+          echo "Release keyword output: ${{ steps.rel.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
         fi
         if [ -n "${{ steps.rel_initial.outputs['version-number'] }}" ]; then
           echo "Initial version keyword output: ${{ steps.rel_initial.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"

--- a/generate-version/action.yml
+++ b/generate-version/action.yml
@@ -1,8 +1,12 @@
-name: "Generate Version"
-description: "Generates a version number based on whether there is a release in the existing repo that matches a keyword.  If not, it will look in the given .csproj file for the current version"
+name: "Generate Semver Version"
+description: "Generates a semver version number.  It will check the releases for the repo is the `release-keyword` is given.  Otherwise, it will reply on the version in the given .csproj file for the current version.  The default behavior is to increment the patch version."
 author: "Trafera"
 
 inputs:
+  increment-type:
+    description: 'Type of version increment (major, minor, patch). If not provided, the version used will be one patch version greater than the version found.  If none of the above are given, the version found will be used.'
+    required: false
+    default: "patch"
   infix-value:
     description: 'Infix value insert between the version number and the date timestamp (e.g., "beta", "alpha", "rc")'
     required: false
@@ -31,6 +35,7 @@ runs:
       shell: bash
       run: node "$GITHUB_ACTION_PATH/generate-version.js"
       env:
+        INPUT_INCREMENT_TYPE: ${{ inputs.increment-type }}
         INPUT_INFIX_VALUE: ${{ inputs.infix-value }}
         INPUT_PROJECT_FILE: ${{ inputs.project-file }}
         INPUT_RELEASE_KEYWORD: ${{ inputs['release-keyword'] }}


### PR DESCRIPTION
This pull request adds support for configurable semantic version increments (major, minor, patch) to the version generation workflow, improves test coverage for these new behaviors, and updates documentation and summary outputs to reflect these enhancements. The default behavior now increments the patch version when generating a new version, unless otherwise specified.

**Version increment support and workflow updates:**

* Added `increment-type` input to `generate-version/action.yml` to allow specifying major, minor, or patch version bumps, with patch as the default. [[1]](diffhunk://#diff-58c317d3f1eea865ea7f3b7253e634135607e1774018feda4fc42ee420de8b3cL1-R9) [[2]](diffhunk://#diff-58c317d3f1eea865ea7f3b7253e634135607e1774018feda4fc42ee420de8b3cR38)
* Implemented `bumpSemver` function in `generate-version/generate-version.js` to handle version increments according to the specified type, and updated the workflow to use the incremented version for output. [[1]](diffhunk://#diff-9695ef0c1d3402358c8b276db4ba67fbaf9452243f74c856d445231c1d117541R28-R45) [[2]](diffhunk://#diff-9695ef0c1d3402358c8b276db4ba67fbaf9452243f74c856d445231c1d117541R115) [[3]](diffhunk://#diff-9695ef0c1d3402358c8b276db4ba67fbaf9452243f74c856d445231c1d117541R162-R174)
* Extended `.github/actions/demo-generate-version/action.yml` workflow to add steps for asserting correct major, minor, and patch bumps, including new tests for each increment type. [[1]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7R53-R61) [[2]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L82-R130)

**Testing and validation improvements:**

* Enhanced `generate-version/generate-version.test.js` with new test cases for all increment types, default patch bump, and fallback scenarios, ensuring correct versioning logic and output. [[1]](diffhunk://#diff-be0bc994dc2aea3370fbb0682afa30ba72259f9b4292c37a68da6810a1685ec7L94-R103) [[2]](diffhunk://#diff-be0bc994dc2aea3370fbb0682afa30ba72259f9b4292c37a68da6810a1685ec7L114-R198) [[3]](diffhunk://#diff-be0bc994dc2aea3370fbb0682afa30ba72259f9b4292c37a68da6810a1685ec7L198-R234)

**Documentation and summary enhancements:**

* Updated action description in `generate-version/action.yml` to clarify semver support and default behavior.
* Improved workflow summary output to display key version outputs for quick reference in the GitHub Actions summary.