### PR TITLE
fix(generate-version): \\ issue in demo 

### DIFF
--- a/.github/actions/demo-generate-version/action.yml
+++ b/.github/actions/demo-generate-version/action.yml
@@ -78,7 +78,7 @@ runs:
         test-name: "base version 1.0.1 for initial version keyword (patch bump)"
         summary-file: ${{ steps.pre.outputs.summary_file }}
         mode: regex
-        expected: '^1\\.0\\.1-'
+        expected: '^1\.0\.1-'
         actual: ${{ steps.rel_initial.outputs['version-number'] }}
 
     - name: Run generate-version (csproj - minor bump)
@@ -95,7 +95,7 @@ runs:
         test-name: "minor bump from 2.3.4 -> 2.4.0"
         summary-file: ${{ steps.pre.outputs.summary_file }}
         mode: regex
-        expected: '^2\\.4\\.0-'
+        expected: '^2\.4\.0-'
         actual: ${{ steps.csproj_minor.outputs['version-number'] }}
 
     - name: Run generate-version (csproj - major bump)
@@ -112,7 +112,7 @@ runs:
         test-name: "major bump from 2.3.4 -> 3.0.0"
         summary-file: ${{ steps.pre.outputs.summary_file }}
         mode: regex
-        expected: '^3\\.0\\.0-'
+        expected: '^3\.0\.0-'
         actual: ${{ steps.csproj_major.outputs['version-number'] }}
 
     - name: Summarize


### PR DESCRIPTION
This pull request makes a minor update to the `.github/actions/demo-generate-version/action.yml` workflow file. The main change is simplifying the regular expression patterns used in the expected version checks for patch, minor, and major bumps by removing unnecessary double backslashes.

- Simplified the regex patterns in the `expected` fields for patch, minor, and major version bump tests, replacing double backslashes with single backslashes in the version number format. [[1]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L81-R81) [[2]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L98-R98) [[3]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L115-R115)