### PR TITLE
chore(release.yml): add tests steps before releasing

### DIFF
--- a/.github/actions/demo-generate-version/action.yml
+++ b/.github/actions/demo-generate-version/action.yml
@@ -72,7 +72,7 @@ runs:
         expected: '^\d+\.\d+\.\d+-[A-Za-z0-9]+-\d{12}$'
         actual: ${{ steps.rel_initial.outputs['version-number'] }}
 
-    - name: Assert base version is 1.0.0 (releases - initial version)
+    - name: Assert base version is 1.0.1 (releases - initial version)
       uses: ./testing/assert
       with:
         test-name: "base version 1.0.1 for initial version keyword (patch bump)"
@@ -135,8 +135,8 @@ runs:
         if [ -n "${{ steps.csproj_major.outputs['version-number'] }}" ]; then
           echo "Csproj (major bump): ${{ steps.csproj_major.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
         fi
-        if [ -n "${{ steps.rel.outputs['version-number'] }}" ]; then
-          echo "Release keyword output: ${{ steps.rel.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
+        if [ -n "${{ steps.rel_initial.outputs['version-number'] }}" ]; then
+          echo "Initial version keyword output: ${{ steps.rel_initial.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"
         fi
         if [ -n "${{ steps.rel_initial.outputs['version-number'] }}" ]; then
           echo "Initial version keyword output: ${{ steps.rel_initial.outputs['version-number'] }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/run-demo-workflows/action.yml
+++ b/.github/actions/run-demo-workflows/action.yml
@@ -1,0 +1,43 @@
+name: Run Demo Workflows (composite)
+description: Executes all demo composite actions used by demo-all workflow
+
+inputs: {}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Demo - code standards (fail)
+      uses: ./.github/actions/demo-code-standards
+      with:
+        directory: "./demo/coding-standards-fail"
+
+    - name: Demo - code standards (fail, roslyn version)
+      uses: ./.github/actions/demo-code-standards
+      with:
+        directory: "./demo/coding-standards-fail"
+        roslyn-version: "4.9.2"
+
+    - name: Demo - code standards (success)
+      uses: ./.github/actions/demo-code-standards
+      with:
+        directory: "./demo/coding-standards-success"
+
+    - name: Demo - dotnet actions
+      uses: ./.github/actions/demo-dotnet-actions
+
+    - name: Demo - generate-version
+      uses: ./.github/actions/demo-generate-version
+      with:
+        infix: "demo"
+
+    - name: Demo - get-changed-files
+      uses: ./.github/actions/demo-get-changed-files
+
+    - name: Demo - get-project-and-solution-files-from-directory
+      uses: ./.github/actions/demo-get-project-and-solution-files-from-directory
+
+    - name: Demo - get-unique-root-directories
+      uses: ./.github/actions/demo-get-unique-root-directories

--- a/.github/actions/run-node-tests/action.yml
+++ b/.github/actions/run-node-tests/action.yml
@@ -1,0 +1,23 @@
+name: Run Node Tests (composite)
+description: Runs the repository's Node.js test suite with coverage and spec reporter
+
+inputs: {}
+
+runs:
+  using: composite
+  steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Node.js
+      uses: ./setup-node
+
+    - name: Run action tests with coverage
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "Running Node tests with coverage"
+        node --version
+        npx --yes c8 -r text -r lcov node --test --test-reporter=spec

--- a/.github/workflows/demo-all.yml
+++ b/.github/workflows/demo-all.yml
@@ -3,84 +3,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  demo-code-standards-fail:
+  run-demos:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        
-      - name: Run demo for code-standards
-        uses: ./.github/actions/demo-code-standards
-        with:
-          directory: './demo/coding-standards-fail'
-  
-  demo-code-standards-fail-version:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        
-      - name: Run demo for code standards
-        uses: ./.github/actions/demo-code-standards
-        with:
-          directory: './demo/coding-standards-fail'
-          roslyn-version: '4.9.2'
-  
-  demo-code-standards-success:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        
-      - name: Run demo for code-standards
-        uses: ./.github/actions/demo-code-standards
-        with:
-          directory: './demo/coding-standards-success'
-
-  demo-dotnet:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Run demo for dotnet actions
-        uses: ./.github/actions/demo-dotnet-actions
-        
-  demo-generate-version:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run demo for generate-version
-        uses: ./.github/actions/demo-generate-version
-        with:
-          infix: 'demo'
-
-  demo-get-changed-files:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run demo for get-changed-files
-        uses: ./.github/actions/demo-get-changed-files
-
-  demo-get-project-and-solution-files:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Run demo for get-project-and-solution-files-from-directory
-        uses: ./.github/actions/demo-get-project-and-solution-files-from-directory
-
-  demo-get-unique-root-directories:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        
-      - name: Run demo for get-unique-root-directories
-        uses: ./.github/actions/demo-get-unique-root-directories
+      - name: Run all demo composites
+        uses: ./.github/actions/run-demo-workflows
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,23 @@ permissions:
   contents: write
 
 jobs:
+  run-node-tests:
+    name: Run Node tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Node tests
+        uses: ./.github/actions/run-node-tests
+
+  run-demo-workflows:
+    name: Run demo workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run demo composites
+        uses: ./.github/actions/run-demo-workflows
+
   publish:
     name: Publish release
+    needs: [run-node-tests, run-demo-workflows]
     runs-on: ubuntu-latest
     outputs:
       release_id: ${{ steps.release_out.outputs.release_id }}
@@ -136,7 +151,7 @@ jobs:
           INPUT_NAME: ${{ inputs.name }}
           INPUT_BODY: ${{ inputs.body }}
           INPUT_TARGET: ${{ inputs.target }}
-          INPUT_DRAFT: ${{ inputs.draft }}t
+          INPUT_DRAFT: ${{ inputs.draft }}
           INPUT_PRERELEASE: ${{ inputs.prerelease }}
           INPUT_GENERATE_NOTES: ${{ inputs.generate-release-notes }}
         with:

--- a/.github/workflows/run-workflow-tests.yml
+++ b/.github/workflows/run-workflow-tests.yml
@@ -5,20 +5,5 @@ jobs:
   run-tests:
     runs-on: ubuntu-22.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          # Fetch full history so that before and after commits exist locally
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: ./setup-node
-
-      - name: Run action tests with coverage
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "Running Node tests in with coverage"
-          node --version
-          # Generates text and lcov coverage reports
-          npx --yes c8 -r text -r lcov node --test --test-reporter=spec
+      - name: Run Node tests
+        uses: ./.github/actions/run-node-tests


### PR DESCRIPTION
This pull request refactors the demo and test workflows to use composite GitHub Actions, improving maintainability and reducing duplication. It introduces new composite actions for running all demo workflows and Node.js tests, updates workflow files to use these composites, and makes minor improvements to version output handling and release workflow logic.

**Workflow and Composite Action Refactoring:**

* Added new composite actions: `run-demo-workflows` and `run-node-tests`, centralizing the execution of demo and Node.js test steps for easier reuse and maintenance. (`.github/actions/run-demo-workflows/action.yml`, `.github/actions/run-node-tests/action.yml`) [[1]](diffhunk://#diff-db92e35f59c1a0cda4dc719e863fbd5a77b082b9d6b65361141457d943bdca63R1-R43) [[2]](diffhunk://#diff-d2dafde4262f5f8f0c1d36ec0c89f81d226b4a55627e509e0e0b309292df88eaR1-R23)
* Updated the `demo-all.yml` workflow to use the new `run-demo-workflows` composite action, replacing multiple individual demo jobs with a single job that runs all demos. (`.github/workflows/demo-all.yml`)
* Updated the `release.yml` workflow to add jobs for running Node tests and demo workflows using the new composites, and made the publish job depend on these test jobs. (`.github/workflows/release.yml`)
* Updated the `run-workflow-tests.yml` workflow to use the new `run-node-tests` composite action instead of inline steps. (`.github/workflows/run-workflow-tests.yml`)

**Minor fixes and improvements:**

* Improved output handling and naming in the `demo-generate-version` action to clarify version outputs and ensure correct assertions. (`.github/actions/demo-generate-version/action.yml`) [[1]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L75-R75) [[2]](diffhunk://#diff-0fad9ce8181c41994f054cbeddd5d6928008544c1613930c79a88280bc6c62a7L138-R139)
* Fixed a typo in the release workflow input mapping for the draft flag. (`.github/workflows/release.yml`)