### PR TITLE
fix: workflow issues

### DIFF
--- a/.github/workflows/demo-all.yml
+++ b/.github/workflows/demo-all.yml
@@ -6,6 +6,11 @@ jobs:
   run-demos:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
       - name: Run all demo composites
         uses: ./.github/actions/run-demo-workflows
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
 
   run-demo-workflows:
     name: Run demo workflows
+    needs: [run-node-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Run demo composites

--- a/.github/workflows/run-workflow-tests.yml
+++ b/.github/workflows/run-workflow-tests.yml
@@ -5,5 +5,10 @@ jobs:
   run-tests:
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
       - name: Run Node tests
         uses: ./.github/actions/run-node-tests


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve reliability and ensure that the repository is properly checked out before running tests and demos. The most important changes are grouped below:

Workflow reliability improvements:

* Added a `Checkout repository` step using `actions/checkout@v4` with `fetch-depth: 0` to both the `run-demos` job in `.github/workflows/demo-all.yml` and the `run-tests` job in `.github/workflows/run-workflow-tests.yml`, ensuring all workflow steps have access to the full repository history. [[1]](diffhunk://#diff-b6a6372889b8bb842d1dd35e61d184995481d87c70a6924f6642154792fead20R9-R13) [[2]](diffhunk://#diff-6db3f717bb4ce586a5b0625cdf3f17ef25e5768c5fcc99db92249266a1695e59R8-R12)

Workflow execution order:

* Updated the `run-demo-workflows` job in `.github/workflows/release.yml` to depend on the completion of the `run-node-tests` job by adding it to the `needs` list, ensuring that demo workflows only run after tests have passed.