### PR TITLE
fix(release-yml): add missing checkout actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ jobs:
     name: Run Node tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
+
       - name: Run Node tests
         uses: ./.github/actions/run-node-tests
 
@@ -57,6 +62,11 @@ jobs:
     needs: [run-node-tests]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 
+            
       - name: Run demo composites
         uses: ./.github/actions/run-demo-workflows
 


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` workflow to ensure that the repository is checked out before running Node tests and demo composites. This helps guarantee that all necessary files are available for subsequent workflow steps.

Workflow improvements:

* Added a `Checkout repository` step using `actions/checkout@v4` with `fetch-depth: 0` before the `Run Node tests` step in the `run-node-tests` job to ensure the full repository history is available.
* Added a `Checkout repository` step using `actions/checkout@v4` with `fetch-depth: 0` before the `Run demo composites` step in the `run-demo-composites` job to ensure the full repository history is available.