### PR TITLE
chore(release.yml): add option to skip tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip-tests:
+        description: 'Skip running tests (not recommended)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -47,6 +52,7 @@ permissions:
 jobs:
   run-node-tests:
     name: Run Node tests
+    if: ${{ inputs.skip-tests != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -59,6 +65,7 @@ jobs:
 
   run-demo-workflows:
     name: Run demo workflows
+    if: ${{ inputs.skip-tests != 'true' }}
     needs: [run-node-tests]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` workflow to add an option for skipping tests during the release process. The main change is the introduction of a `skip-tests` input, which allows users to bypass running tests if needed.

Workflow configuration improvements:

* Added a new `skip-tests` input to the workflow, allowing users to optionally skip running tests during the release process.
* Updated both the `run-node-tests` and `run-demo-workflows` jobs to conditionally run only if `skip-tests` is not set to `true`. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R43-R55) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R68)