### PR TITLE
fix(release.yml: checkout issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
     name: Run Node tests
     runs-on: ubuntu-latest
     steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
         - name: Run Node tests
           if: ${{ !fromJson(inputs['skip-tests']) }}
           uses: ./.github/actions/run-node-tests
@@ -65,6 +69,10 @@ jobs:
     name: Run demo workflows
     runs-on: ubuntu-latest
     steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
         - name: Run demo composites
           if: ${{ !fromJson(inputs['skip-tests']) }}
           uses: ./.github/actions/run-demo-workflows


### PR DESCRIPTION
This pull request updates the workflow configuration in `.github/workflows/release.yml` to ensure that the repository is checked out before running tests and demo workflows. This change improves reliability by making sure the necessary code is available for subsequent steps.

Workflow improvements:

* Added a `Checkout repository` step using `actions/checkout@v4` with `fetch-depth: 0` to the `Run Node tests` job, ensuring the repository is available before tests run.
* Added a `Checkout repository` step using `actions/checkout@v4` with `fetch-depth: 0` to the `Run demo workflows` job, ensuring the repository is available before demo composites run.