### PR TITLE
fix(run-demo-workflows.yml): missing inputs

### DIFF
--- a/.github/actions/run-demo-workflows/action.yml
+++ b/.github/actions/run-demo-workflows/action.yml
@@ -36,7 +36,10 @@ runs:
     - name: Demo - nuget publish
       uses: ./.github/actions/demo-nuget-publish
       with:
+        additional-build-args: --property WarningLevel=0 /p:VersionSuffix=1.0.0
+        additional-pack-args: --output nupkgs /p:VersionSuffix=1.0.0 /p:PackageVersion=1.0.0
         directory: "demo/dotnet/src/Api"
+        github-token: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
 
     - name: Demo - get-changed-files
       uses: ./.github/actions/demo-get-changed-files

--- a/nuget/publish/publish.js
+++ b/nuget/publish/publish.js
@@ -5,6 +5,7 @@ const { spawnSync } = require('child_process');
 
 function log(msg) { process.stdout.write(`${msg}\n`); }
 function error(msg) { process.stderr.write(`${msg}\n`); }
+function maskToken(t) { if (!t) return ''; return `${t.slice(0, 3)}…${t.slice(-3)}`; }
 
 function run() {
     try {
@@ -14,37 +15,51 @@ function run() {
         const publishSource = process.env.INPUT_PUBLISH_SOURCE || '';
         const token = process.env.INPUT_GITHUB_TOKEN || '';
 
-        if (!fs.existsSync(pkgDir)) {
-            error(`nupkgs directory not found: ${pkgDir}`);
-            process.exit(1);
-        }
+        // Session header (ASCII only for log stability)
+        log('nuget/publish starting');
+        log(`Node: ${process.version} | PID: ${process.pid}`);
+        log(`workspace: ${workspace}`);
+        log(`actionPath: ${actionPath}`);
+        log(`pkgDir: ${pkgDir}`);
+        log(`publishSource (raw): ${publishSource || '(empty)'}`);
 
-        const files = fs.readdirSync(pkgDir).filter(f => f.endsWith('.nupkg'));
+
+        const allEntries = fs.readdirSync(pkgDir);
+        log(`entries in pkgDir: ${allEntries.length}`);
+        const files = allEntries.filter(f => f.endsWith('.nupkg'));
+        log(`nupkg files detected: ${files.length}`);
         if (files.length === 0) {
             error('No .nupkg files found to publish');
             process.exit(1);
         }
 
-        log(`Publishing packages from ${pkgDir}`);
-        files.forEach(f => log(` - ${f}`));
+        log('Package list:');
+        files.forEach(f => log(`   - ${f}`));
 
         let target = publishSource && publishSource.trim();
         if (!target) {
             const owner = (process.env.GITHUB_REPOSITORY_OWNER || '').trim();
+            log(`no publish-source provided; owner: ${owner || '(missing)'}`);
             if (!owner) {
                 error('GITHUB_REPOSITORY_OWNER is not set and no publish-source provided');
                 process.exit(1);
             }
             target = `https://nuget.pkg.github.com/${owner}/index.json`;
         }
+        log(`resolved target: ${target}`);
 
         // Local folder publish if absolute or relative path
         const looksLocal = /^(\.|\/|[A-Za-z]:\\)/.test(target);
+        log(`looksLocal: ${looksLocal}`);
         if (looksLocal) {
             const dest = path.isAbsolute(target) ? target : path.join(workspace, target);
+            log(`Local publish to: ${dest}`);
             fs.mkdirSync(dest, { recursive: true });
             for (const f of files) {
-                fs.copyFileSync(path.join(pkgDir, f), path.join(dest, f));
+                const from = path.join(pkgDir, f);
+                const to = path.join(dest, f);
+                log(`   copy ${from} -> ${to}`);
+                fs.copyFileSync(from, to);
             }
             log(`Copied ${files.length} package(s) to ${dest}`);
             return;
@@ -58,13 +73,17 @@ function run() {
         // Push to remote via dotnet nuget push
         const pattern = path.join(pkgDir, '*.nupkg');
         const args = ['nuget', 'push', pattern, '--api-key', token, '--source', target];
-        log(`Executing: dotnet ${args.join(' ')}`);
+        log(`Remote publish using dotnet`);
+        log(`   pattern: ${pattern}`);
+        log(`   source: ${target}`);
+        log(`   api-key: ${maskToken(token)}`);
+        log(`   command: dotnet ${args.join(' ')}`);
         const r = spawnSync('dotnet', args, { stdio: 'inherit' });
         if (r.status !== 0) {
             error(`dotnet nuget push failed with code ${r.status}`);
             process.exit(r.status || 1);
         }
-        log('Push completed successfully');
+    log('Push completed successfully');
     } catch (e) {
         error(e && e.stack || String(e));
         process.exit(1);

--- a/nuget/publish/publish.js
+++ b/nuget/publish/publish.js
@@ -5,7 +5,6 @@ const { spawnSync } = require('child_process');
 
 function log(msg) { process.stdout.write(`${msg}\n`); }
 function error(msg) { process.stderr.write(`${msg}\n`); }
-function maskToken(t) { if (!t) return ''; return `${t.slice(0, 3)}…${t.slice(-3)}`; }
 
 function run() {
     try {
@@ -15,56 +14,37 @@ function run() {
         const publishSource = process.env.INPUT_PUBLISH_SOURCE || '';
         const token = process.env.INPUT_GITHUB_TOKEN || '';
 
-        // Session header (ASCII only for log stability)
-        log('nuget/publish starting');
-        log(`Node: ${process.version} | PID: ${process.pid}`);
-        log(`workspace: ${workspace}`);
-        log(`actionPath: ${actionPath}`);
-        log(`pkgDir: ${pkgDir}`);
-        log(`publishSource (raw): ${publishSource || '(empty)'}`);
-
-        // Validate nupkgs directory
         if (!fs.existsSync(pkgDir)) {
-            error('nupkgs directory not found');
+            error(`nupkgs directory not found: ${pkgDir}`);
             process.exit(1);
         }
 
-        const allEntries = fs.readdirSync(pkgDir);
-        log(`entries in pkgDir: ${allEntries.length}`);
-        const files = allEntries.filter(f => f.endsWith('.nupkg'));
-        log(`nupkg files detected: ${files.length}`);
+        const files = fs.readdirSync(pkgDir).filter(f => f.endsWith('.nupkg'));
         if (files.length === 0) {
             error('No .nupkg files found to publish');
             process.exit(1);
         }
 
-        log('Package list:');
-        files.forEach(f => log(`   - ${f}`));
+        log(`Publishing packages from ${pkgDir}`);
+        files.forEach(f => log(` - ${f}`));
 
         let target = publishSource && publishSource.trim();
         if (!target) {
             const owner = (process.env.GITHUB_REPOSITORY_OWNER || '').trim();
-            log(`no publish-source provided; owner: ${owner || '(missing)'}`);
             if (!owner) {
                 error('GITHUB_REPOSITORY_OWNER is not set and no publish-source provided');
                 process.exit(1);
             }
             target = `https://nuget.pkg.github.com/${owner}/index.json`;
         }
-        log(`resolved target: ${target}`);
 
         // Local folder publish if absolute or relative path
         const looksLocal = /^(\.|\/|[A-Za-z]:\\)/.test(target);
-        log(`looksLocal: ${looksLocal}`);
         if (looksLocal) {
             const dest = path.isAbsolute(target) ? target : path.join(workspace, target);
-            log(`Local publish to: ${dest}`);
             fs.mkdirSync(dest, { recursive: true });
             for (const f of files) {
-                const from = path.join(pkgDir, f);
-                const to = path.join(dest, f);
-                log(`   copy ${from} -> ${to}`);
-                fs.copyFileSync(from, to);
+                fs.copyFileSync(path.join(pkgDir, f), path.join(dest, f));
             }
             log(`Copied ${files.length} package(s) to ${dest}`);
             return;
@@ -78,17 +58,13 @@ function run() {
         // Push to remote via dotnet nuget push
         const pattern = path.join(pkgDir, '*.nupkg');
         const args = ['nuget', 'push', pattern, '--api-key', token, '--source', target];
-        log(`Remote publish using dotnet`);
-        log(`   pattern: ${pattern}`);
-        log(`   source: ${target}`);
-        log(`   api-key: ${maskToken(token)}`);
-        log(`   command: dotnet ${args.join(' ')}`);
+        log(`Executing: dotnet ${args.join(' ')}`);
         const r = spawnSync('dotnet', args, { stdio: 'inherit' });
         if (r.status !== 0) {
             error(`dotnet nuget push failed with code ${r.status}`);
             process.exit(r.status || 1);
         }
-    log('Push completed successfully');
+        log('Push completed successfully');
     } catch (e) {
         error(e && e.stack || String(e));
         process.exit(1);

--- a/nuget/publish/publish.js
+++ b/nuget/publish/publish.js
@@ -8,6 +8,7 @@ function error(msg) { process.stderr.write(`${msg}\n`); }
 function maskToken(t) { if (!t) return ''; return `${t.slice(0, 3)}…${t.slice(-3)}`; }
 
 function run() {
+    const t0 = Date.now();
     try {
         const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
         const actionPath = process.env.GITHUB_ACTION_PATH || __dirname;
@@ -23,6 +24,11 @@ function run() {
         log(`pkgDir: ${pkgDir}`);
         log(`publishSource (raw): ${publishSource || '(empty)'}`);
 
+        // Validate nupkgs directory
+        if (!fs.existsSync(pkgDir)) {
+            error('nupkgs directory not found');
+            process.exit(1);
+        }
 
         const allEntries = fs.readdirSync(pkgDir);
         log(`entries in pkgDir: ${allEntries.length}`);
@@ -62,6 +68,7 @@ function run() {
                 fs.copyFileSync(from, to);
             }
             log(`Copied ${files.length} package(s) to ${dest}`);
+            log(`Done in ${Date.now() - t0} ms`);
             return;
         }
 
@@ -83,7 +90,8 @@ function run() {
             error(`dotnet nuget push failed with code ${r.status}`);
             process.exit(r.status || 1);
         }
-    log('Push completed successfully');
+        log('Push completed successfully');
+        log(`Done in ${Date.now() - t0} ms`);
     } catch (e) {
         error(e && e.stack || String(e));
         process.exit(1);

--- a/nuget/publish/publish.test.js
+++ b/nuget/publish/publish.test.js
@@ -28,6 +28,13 @@ function mkpkg(tmp) {
     return nupkgs;
 }
 
+test('fails when nupkgs missing', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'npub-'));
+    const r = withEnv({ GITHUB_WORKSPACE: tmp }, () => run());
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /nupkgs directory not found/);
+});
+
 test('fails when no nupkg files', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'npub-'));
     fs.mkdirSync(path.join(tmp, 'nupkgs'));

--- a/nuget/publish/publish.test.js
+++ b/nuget/publish/publish.test.js
@@ -28,13 +28,6 @@ function mkpkg(tmp) {
     return nupkgs;
 }
 
-test('fails when nupkgs missing', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'npub-'));
-    const r = withEnv({ GITHUB_WORKSPACE: tmp }, () => run());
-    assert.strictEqual(r.exitCode, 1);
-    assert.match(r.err, /nupkgs directory not found/);
-});
-
 test('fails when no nupkg files', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'npub-'));
     fs.mkdirSync(path.join(tmp, 'nupkgs'));


### PR DESCRIPTION
This pull request introduces improvements to the demo NuGet publish workflow and enhances logging in the NuGet publish script. The main changes focus on enabling more flexible build and packaging options for the workflow and providing better visibility into execution times for publishing operations.

**Workflow improvements:**

* Added support for passing additional build and pack arguments (`additional-build-args`, `additional-pack-args`) to the demo NuGet publish workflow in `.github/actions/run-demo-workflows/action.yml`, allowing for custom warning levels and version suffixes.
* Included a `github-token` input for authenticating with GitHub Packages in the demo NuGet publish workflow.

**Logging enhancements:**

* Added timing logs to the `nuget/publish/publish.js` script to report the duration of package copying and push operations, improving visibility into workflow performance. [[1]](diffhunk://#diff-93d6e4f79bcbdc76b6c7af81ea259ad448d2488f22ced0516cd9e96ac125b05fR11) [[2]](diffhunk://#diff-93d6e4f79bcbdc76b6c7af81ea259ad448d2488f22ced0516cd9e96ac125b05fR71) [[3]](diffhunk://#diff-93d6e4f79bcbdc76b6c7af81ea259ad448d2488f22ced0516cd9e96ac125b05fR94)