### PR TITLE
chore(nuget/publish): add input for project-file

### DIFF
--- a/.github/actions/demo-nuget-publish/action.yml
+++ b/.github/actions/demo-nuget-publish/action.yml
@@ -28,6 +28,27 @@ runs:
         echo "SUMMARY_FILE=$GITHUB_WORKSPACE/demo-nuget-publish-summary.txt" >> $GITHUB_ENV
         : > $GITHUB_WORKSPACE/demo-nuget-publish-summary.txt
 
+    - name: Run nuget/publish with missing inputs (expected fail)
+      id: nuget_publish_missing
+      continue-on-error: true
+      uses: ./nuget/publish
+      with:
+        additional-build-args: ${{ inputs.additional-build-args }}
+        additional-pack-args: ${{ inputs.additional-pack-args }}
+        directory: ""
+        dotnet-version: "8.0.x"
+        github-token: ${{ inputs.github-token }}
+        project-file: ""
+
+    - name: Assert missing inputs caused failure
+      uses: ./testing/assert
+      with:
+        expected: failure
+        mode: exact
+        actual: ${{ steps.nuget_publish_missing.outcome }}
+        test-name: "missing inputs -> failure"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
     - name: Run nuget/publish (expected to fail push)
       id: nuget_publish
       continue-on-error: true
@@ -39,6 +60,15 @@ runs:
         dotnet-version: "8.0.x"
         github-token: ${{ inputs.github-token }}
         project-regex: 'Api\.csproj$'
+
+    - name: Assert remote publish without token failed
+      uses: ./testing/assert
+      with:
+        expected: failure
+        mode: exact
+        actual: ${{ steps.nuget_publish.outcome }}
+        test-name: "remote publish without token -> failure"
+        summary-file: ${{ env.SUMMARY_FILE }}
 
     - name: Assert nupkg exists
       uses: ./testing/assert
@@ -74,6 +104,28 @@ runs:
         mode: present
         actual: ${{ (hashFiles('.artifacts/nuget-local/*.nupkg') != '') && 'present' || '' }}
         test-name: "local publish succeeded"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Run nuget/publish using project-file (success to local folder)
+
+      id: nuget_publish_pf
+      uses: ./nuget/publish
+      with:
+        additional-build-args: ${{ inputs.additional-build-args }}
+        additional-pack-args: ${{ inputs.additional-pack-args }}
+        directory: ""
+        project-file: demo/dotnet/src/Api/Api.csproj
+        dotnet-version: "8.0.x"
+        github-token: ${{ inputs.github-token }}
+        publish-source: ".artifacts/nuget-local-pf"
+
+    - name: Assert locally published nupkg exists (project-file)
+      uses: ./testing/assert
+      with:
+        expected: present
+        mode: present
+        actual: ${{ (hashFiles('.artifacts/nuget-local-pf/*.nupkg') != '') && 'present' || '' }}
+        test-name: "local publish with project-file succeeded"
         summary-file: ${{ env.SUMMARY_FILE }}
 
     - name: Summary

--- a/nuget/publish/README.md
+++ b/nuget/publish/README.md
@@ -1,0 +1,73 @@
+# nuget/publish
+
+Deploys a NuGet package built from a .NET project to a destination:
+- Local folder (for demos/testing) when `publish-source` is a path.
+- GitHub Packages (default) when `publish-source` is omitted. Requires a GitHub token.
+
+This composite orchestrates:
+- Project resolution (either a provided project file or discovery from a directory and project-regex).
+- Build/pack via `dotnet/build` (mode: pack).
+- Package publication via `publish.js`.
+
+## Key behavior
+- You must provide either `project-file` or `directory`.
+  - If both are provided, `project-file` is used.
+  - If neither is provided, the action exits with an error.
+- Packing should output `.nupkg` files to `nupkgs/` at the workspace root.
+- If `publish-source` looks like a path (relative or absolute), packages are copied there.
+- If `publish-source` is omitted, packages are pushed to GitHub Packages using the repository owner.
+- A token is required only for remote pushes; local folder copies don’t require a token.
+
+## Inputs
+- additional-build-args (optional): Extra args for `dotnet build`.
+- additional-pack-args (optional): Extra args for `dotnet pack` (use `--output nupkgs`).
+- debug-mode (optional): Extra logs for discovery.
+- directory (optional): Directory to search for a `.csproj`. Mutually exclusive with `project-file`.
+- dotnet-version (optional): .NET SDK version (default `9.0.x`).
+- github-token (required): Token for remote publish (GitHub Packages). Not used for local copies.
+- nuget-names/nuget-usernames/nuget-passwords/nuget-urls (optional): NuGet source configuration passed to `dotnet/build`.
+- project-file (optional): Full path to a `.csproj`. Mutually exclusive with `directory`.
+- project-regex (optional): Used with `directory` to select a project.
+- publish-source (optional): Target location; omit to default to GitHub Packages.
+- run-tests (optional): Run `dotnet test` for the resolved project.
+
+## Outputs
+- None.
+
+## Examples
+
+Using a project file, publish to a local folder (for demo):
+
+```yaml
+- name: NuGet publish (project-file to local)
+  uses: Now-Micro/actions/nuget/publish@v1
+  with:
+    project-file: demo/dotnet/src/Api/Api.csproj
+    additional-pack-args: --output nupkgs /p:PackageVersion=1.0.0
+    publish-source: .artifacts/nuget-local
+    github-token: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
+```
+
+Discover from a directory and publish to GitHub Packages (default target):
+
+```yaml
+- name: NuGet publish (directory -> GitHub Packages)
+  uses: Now-Micro/actions/nuget/publish@v1
+  with:
+    directory: demo/dotnet/src/Api
+    project-regex: 'Api\.csproj$'
+    additional-pack-args: --output nupkgs /p:PackageVersion=1.0.0
+    github-token: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
+```
+
+## Demos
+See `.github/actions/demo-nuget-publish` and workflow `.github/workflows/demo-nuget-publish.yml` for end-to-end scenarios:
+- Missing inputs validation (expect failure)
+- Remote publish without token (expect failure)
+- Local publish (success) using `directory`
+- Local publish (success) using `project-file`
+
+## Troubleshooting
+- Error: "Either 'project-file' or 'directory' must be provided." — Provide one of these inputs.
+- Error: "No .nupkg files found to publish" — Ensure pack outputs to `nupkgs/` (via `--output nupkgs`).
+- Error: "INPUT_GITHUB_TOKEN is required to push to remote source" — Provide `github-token` when pushing to remote (GitHub Packages).

--- a/nuget/publish/action.yml
+++ b/nuget/publish/action.yml
@@ -8,14 +8,14 @@ inputs:
   additional-pack-args:
     description: "Additional arguments to pass to dotnet pack."
     required: false
-    default: ""
+    default: "--output nupkgs"
   debug-mode:
     description: "Enable debug mode for additional logging."
     required: false
     default: "false"
   directory:
-    description: "The directory to search for a .csproj file."
-    required: true
+    description: "The directory to search for a .csproj file.  If not specified, the `project-file` input must be specified, otherwise an error will be thrown."
+    required: false
   dotnet-version:
     description: "The version of .NET to use."
     required: false
@@ -35,6 +35,10 @@ inputs:
   nuget-usernames:
     description: "Usernames for source authentication (comma-separated)"
     required: false
+  project-file:
+    description: "Path to the project file. If not specified, The `directory` input must be specified otherwise an error will be thrown."
+    required: false
+    default: ""
   project-regex:
     description: "Regular expression to identify project file desired."
     required: false
@@ -51,9 +55,22 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        PF="${{ inputs.project-file }}"
+        DIR="${{ inputs.directory }}"
+        if [ -z "${PF}" ] && [ -z "${DIR}" ]; then
+          echo "Error: Either 'project-file' or 'directory' must be provided." >&2
+          exit 1
+        fi
+        if [ -n "${PF}" ] && [ -n "${DIR}" ]; then
+          echo "Info: Both 'project-file' and 'directory' provided; 'project-file' will be used."
+        fi
     - name: Get Project File
       id: extract-project
       uses: Now-Micro/actions/get-project-and-solution-files-from-directory@v1
+      if: ${{ inputs.project-file == '' }}
       with:
         directory: ${{ inputs.directory }}
         debug-mode: ${{ inputs.debug-mode }}
@@ -61,13 +78,23 @@ runs:
         find-solution: false
         project-regex: ${{ inputs.project-regex }}
 
+    - name: Resolve Project Path
+      id: resolve
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.project-file }}" ]; then
+          echo "path=${{ inputs.project-file }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=${{ steps.extract-project.outputs.project-found }}" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Build Project (pack)
       id: build
       uses: Now-Micro/actions/dotnet/build@v1
       with:
         additional-pack-args: ${{ inputs.additional-pack-args }}
         dotnet-version: ${{ inputs.dotnet-version }}
-        file-to-build: ${{ steps.extract-project.outputs.project-found }}
+        file-to-build: ${{ steps.resolve.outputs.path }}
         mode: "pack"
         nuget-names: ${{ inputs.nuget-names }}
         nuget-passwords: ${{ inputs.nuget-passwords }}
@@ -77,7 +104,7 @@ runs:
     - name: Test
       if: ${{ inputs.run-tests == 'true' }}
       shell: bash
-      run: dotnet test --no-restore "${{ steps.extract-project.outputs.project-found }}"
+      run: dotnet test --no-restore "${{ steps.resolve.outputs.path }}"
 
     - name: Publish NuGet Package
       shell: bash


### PR DESCRIPTION
This pull request enhances the `nuget/publish` GitHub Action by improving input validation, flexibility, and documentation. The most significant changes ensure that either a project file or directory is specified, clarify input requirements, and add comprehensive usage documentation. Additionally, the demo workflow is expanded to test for missing inputs and project-file-based publishing.

**Input validation and flexibility:**

* Added a validation step in `nuget/publish/action.yml` to ensure that either `project-file` or `directory` is provided, and clarified that `project-file` takes precedence if both are set. The action now fails early with a clear error message if neither is provided.
* Changed the `directory` input to be optional instead of required, and updated its description to reflect the new validation logic.
* Added a new optional `project-file` input, with a description and default value, allowing direct specification of a `.csproj` path.
* Updated steps to resolve the project path using either `project-file` or the extracted project from the directory, and consistently use this resolved path in subsequent build and test steps. [[1]](diffhunk://#diff-b052df209ef052464938d9d4e5b541c87f3195c049cb69abef029912634b529aR58-R97) [[2]](diffhunk://#diff-b052df209ef052464938d9d4e5b541c87f3195c049cb69abef029912634b529aL80-R107)

**Documentation improvements:**

* Added a comprehensive `README.md` for `nuget/publish`, detailing key behaviors, inputs, outputs, usage examples, demo scenarios, and troubleshooting tips.
* Set the default value of `additional-pack-args` to `--output nupkgs` to ensure consistent output location for package files.

**Demo workflow enhancements:**

* Expanded `.github/actions/demo-nuget-publish/action.yml` to include tests for missing inputs (expected failure), remote publish without a token (expected failure), and successful local publish using `project-file`, improving coverage of key scenarios. [[1]](diffhunk://#diff-836c1619edda7502d008971438f61cc9b6108127838d945be5290d2ac476e063R31-R51) [[2]](diffhunk://#diff-836c1619edda7502d008971438f61cc9b6108127838d945be5290d2ac476e063R64-R72) [[3]](diffhunk://#diff-836c1619edda7502d008971438f61cc9b6108127838d945be5290d2ac476e063R109-R130)