### PR TITLE
chore: change run-tests to test-project-file for input

### DIFF
--- a/nuget/publish/README.md
+++ b/nuget/publish/README.md
@@ -29,7 +29,7 @@ This composite orchestrates:
 - project-file (optional): Full path to a `.csproj`. Mutually exclusive with `directory`.
 - project-regex (optional): Used with `directory` to select a project.
 - publish-source (optional): Target location; omit to default to GitHub Packages.
-- run-tests (optional): Run `dotnet test` for the resolved project.
+- test-project-file (optional): Full path to a `.csproj` for running tests. 
 
 ## Outputs
 - None.

--- a/nuget/publish/action.yml
+++ b/nuget/publish/action.yml
@@ -51,10 +51,10 @@ inputs:
     description: "Publish destination. Leave empty for GitHub Packages; provide a folder path for local demo."
     required: false
     default: ""
-  run-tests:
-    description: "Whether to run tests as part of the build process."
+  test-project-file:
+    description: "Path to the test project file.  If not specified, tests will not be run."
     required: false
-    default: "false"
+    default: ""
 
 runs:
   using: "composite"
@@ -106,9 +106,9 @@ runs:
         nuget-usernames: ${{ inputs.nuget-usernames }}
 
     - name: Test
-      if: ${{ inputs.run-tests == 'true' }}
+      if: ${{ inputs.test-project-file != '' }}
       shell: bash
-      run: dotnet test --no-restore "${{ steps.resolve.outputs.path }}"
+      run: dotnet test --no-restore ${{ inputs.test-project-file }}
 
     - name: Publish NuGet Package
       shell: bash


### PR DESCRIPTION
This pull request updates the NuGet publish workflow to improve how tests are run during the build process. The main change is replacing the generic `run-tests` flag with a more precise `test-project-file` input, allowing users to specify which test project to run.

**Workflow input and behavior updates:**

* Replaced the `run-tests` boolean input with a new `test-project-file` input in `action.yml`, enabling users to specify the exact test project for running tests.
* Updated the test execution step in `action.yml` to run `dotnet test` only if `test-project-file` is provided, and to use the specified file path for tests.

**Documentation updates:**

* Modified the `README.md` to document the new `test-project-file` input and remove references to the old `run-tests` flag.