### PR TITLE
chore(get-project-and-solution-files-from-directory): add ignored-directories input

### DIFF
--- a/get-project-and-solution-files-from-directory/action.yml
+++ b/get-project-and-solution-files-from-directory/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Regular expression to identify solution file desired.  If empty, will return the first .sln file found."
     required: false
     default: ""
+  ignored-directories:
+    description: "Comma-separated list of directory names to ignore when considering matches (e.g., /bin,/obj,/node_modules).  If a .csproj or .sln file path matches any of these values, it will be ignored."
+    required: false
+    default: "/bin,/obj,/node_modules"
 
 outputs:
   project-found:
@@ -58,6 +62,7 @@ runs:
         INPUT_DIRECTORY: ${{ inputs.directory }}
         INPUT_FIND_PROJECT: ${{ inputs.find-project }}
         INPUT_FIND_SOLUTION: ${{ inputs.find-solution }}
+        INPUT_IGNORED_DIRECTORIES: ${{ inputs.ignored-directories }}
         INPUT_MAX_DEPTH: ${{ inputs.max-depth }}
         INPUT_PROJECT_REGEX: ${{ inputs.project-regex }}
         INPUT_SOLUTION_REGEX: ${{ inputs.solution-regex }}


### PR DESCRIPTION
This pull request adds support for ignoring specified directories when searching for project and solution files, enhancing the flexibility and accuracy of the directory scanning logic. The changes include updates to the action input schema, the core search algorithm, and comprehensive new tests to validate the feature.

### Feature: Ignored Directories Support

* Added a new input `ignored-directories` to `action.yml`, allowing users to specify a comma-separated list of directory names to ignore during the search.
* Updated the environment variable mapping in `action.yml` to pass `ignored-directories` to the script.

### Implementation: Search Algorithm Enhancements

* Implemented `parseIgnored` and `pathHasIgnoredSegment` helper functions in `get-project-and-solution-files-from-directory.js` to handle parsing and matching ignored directories.
* Modified the BFS search logic to skip files and directories matching any ignored names, ensuring only desired paths are considered [[1]](diffhunk://#diff-b5ec073a5f94fb649e1d6eaae06fbb5b2c9ac477a54302305adddc7719d87823R70) [[2]](diffhunk://#diff-b5ec073a5f94fb649e1d6eaae06fbb5b2c9ac477a54302305adddc7719d87823R90) [[3]](diffhunk://#diff-b5ec073a5f94fb649e1d6eaae06fbb5b2c9ac477a54302305adddc7719d87823L127-R147).
* Updated logging to display ignored directories for easier debugging and traceability.

### Testing: Comprehensive Coverage

* Added multiple tests in `get-project-and-solution-files-from-directory.test.js` to verify that ignored directories are correctly excluded during project and solution file selection, including cases where only ignored paths contain matches.

These changes collectively ensure that unwanted directories (such as `bin`, `obj`, or `node_modules`) are excluded from search results, improving the reliability of project and solution file detection in complex directory structures.…d ignore-directories