### PR TITLE
chore(generate-version): add input called add-timestamp

### DIFF
--- a/generate-version/action.yml
+++ b/generate-version/action.yml
@@ -1,10 +1,14 @@
 name: "Generate Semver Version"
-description: "Generates a semver version number.  It will check the releases for the repo is the `release-keyword` is given.  Otherwise, it will reply on the version in the given .csproj file for the current version.  The default behavior is to increment the patch version."
+description: "Generates a semver version number.  It will check the releases in the repo for a base version if the `release-keyword` is given.  Otherwise, it will reply on the version value in the .csproj file.  The default behavior is to increment the patch version."
 author: "Trafera"
 
 inputs:
+  add-timestamp:
+    description: "Whether to append a UTC YYYYMMDDHHmm timestamp to the version. Defaults to true."
+    required: false
+    default: "true"
   increment-type:
-    description: 'Type of version increment (major, minor, patch). If not provided, the version used will be one patch version greater than the version found.  If none of the above are given, the version found will be used.'
+    description: "Type of version increment (major, minor, patch). If not provided, the version used will be one patch version greater than the version found.  If none of the above are given, the version found will be used."
     required: false
     default: "patch"
   infix-value:
@@ -35,6 +39,7 @@ runs:
       shell: bash
       run: node "$GITHUB_ACTION_PATH/generate-version.js"
       env:
+        INPUT_ADD_TIMESTAMP: ${{ inputs['add-timestamp'] }}
         INPUT_INCREMENT_TYPE: ${{ inputs.increment-type }}
         INPUT_INFIX_VALUE: ${{ inputs.infix-value }}
         INPUT_PROJECT_FILE: ${{ inputs.project-file }}

--- a/generate-version/generate-version.js
+++ b/generate-version/generate-version.js
@@ -116,8 +116,9 @@ async function run() {
     const projectFile = process.env.INPUT_PROJECT_FILE;
     const infix = (process.env.INPUT_INFIX_VALUE || '').trim();
     const releaseKeyword = (process.env.INPUT_RELEASE_KEYWORD || '').trim();
+    const addTimestamp = String(process.env.INPUT_ADD_TIMESTAMP ?? 'true').toLowerCase() !== 'false';
     const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
-    console.log(`🔍 Inputs: projectFile=${projectFile || '(none)'} infix=${infix || '(none)'} releaseKeyword=${releaseKeyword || '(none)'} `);
+    console.log(`🔍 Inputs: projectFile=${projectFile || '(none)'} infix=${infix || '(none)'} releaseKeyword=${releaseKeyword || '(none)'} addTimestamp=${addTimestamp}`);
 
     if (!projectFile && !releaseKeyword) {
         exitWith('INPUT_PROJECT_FILE is required when release-keyword is not provided');
@@ -167,13 +168,13 @@ async function run() {
         console.log(`ℹ️ Using base version without increment: ${baseVersion}`);
     }
 
-    // Build final version: versionNumber-infix-timestamp
+    // Build final version: versionNumber[-infix][-timestamp]
     const ts = new Date();
     const pad = n => String(n).padStart(2, '0');
     const timestamp = `${ts.getUTCFullYear()}${pad(ts.getUTCMonth() + 1)}${pad(ts.getUTCDate())}${pad(ts.getUTCHours())}${pad(ts.getUTCMinutes())}`;
     const parts = [effectiveVersion];
     if (infix) parts.push(infix);
-    parts.push(timestamp);
+    if (addTimestamp) parts.push(timestamp);
     const version = parts.join('-');
 
     // Output

--- a/generate-version/generate-version.test.js
+++ b/generate-version/generate-version.test.js
@@ -199,6 +199,28 @@ test('unknown increment-type uses base version (no bump)', async () => {
     restoreDate();
 });
 
+test('skips timestamp when add-timestamp=false (with infix)', async () => {
+    const restoreDate = mockDate('2024-07-08T09:10:00Z');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gvts-'));
+    const csproj = path.join(dir, 'App.csproj');
+    fs.writeFileSync(csproj, '<Project><PropertyGroup><Version>1.2.3</Version></PropertyGroup></Project>');
+    const r = await runWith({ INPUT_PROJECT_FILE: csproj, INPUT_INFIX_VALUE: 'beta', INPUT_ADD_TIMESTAMP: 'false' });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=1.2.4-beta\n/);
+    restoreDate();
+});
+
+test('skips timestamp when add-timestamp=false (no infix)', async () => {
+    const restoreDate = mockDate('2024-07-08T09:10:00Z');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gvts2-'));
+    const csproj = path.join(dir, 'App.csproj');
+    fs.writeFileSync(csproj, '<Project><PropertyGroup><Version>1.2.3</Version></PropertyGroup></Project>');
+    const r = await runWith({ INPUT_PROJECT_FILE: csproj, INPUT_ADD_TIMESTAMP: false });
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.outputContent, /version_number=1.2.4\n/);
+    restoreDate();
+});
+
 test('errors on invalid semver in project file', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gve-'));
     const csproj = path.join(dir, 'Bad.csproj');


### PR DESCRIPTION
This pull request adds a new feature to the version generation workflow, allowing users to optionally skip appending a timestamp to the generated version number. By default, timestamps are still included, but this can now be controlled via a new input parameter. The implementation includes updates to documentation, environment variable handling, version string construction, and new tests to verify the behavior.

**Feature: Optional timestamp in version number**

* Added a new input parameter `add-timestamp` to `action.yml`, allowing users to control whether a UTC timestamp is appended to the version number. The default is `"true"`.
* Updated the environment variables in the `runs` section of `action.yml` to pass the new `add-timestamp` input to the script.
* Modified `generate-version.js` to read the `add-timestamp` input, log its value, and conditionally append the timestamp to the version string only if enabled. [[1]](diffhunk://#diff-9695ef0c1d3402358c8b276db4ba67fbaf9452243f74c856d445231c1d117541R119-R121) [[2]](diffhunk://#diff-9695ef0c1d3402358c8b276db4ba67fbaf9452243f74c856d445231c1d117541L170-R177)

**Testing**

* Added two new tests to `generate-version.test.js` to verify that the timestamp is correctly omitted from the version number when `add-timestamp` is set to false, both with and without an infix value.