### PR TITLE
ci: add workflow for webhook

### DIFF
--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -6,6 +6,8 @@ on:
     pull_request:
         types: [closed]
         branches: [main]
+    release:
+        types: [published]
     workflow_dispatch:
 
 concurrency:
@@ -21,4 +23,3 @@ jobs:
                   curl --fail -sS -X POST "${{vars.MCP_WEBHOOK_URL}}" \
                       -H "Content-Type: application/json" \
                       -H "${{secrets.MCP_AUTH_HEADER}}: ${{secrets.MCP_AUTH_TOKEN}}" \
-                  

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -1,0 +1,22 @@
+name: Notify external MCP server of new Content (e.g., to invalidate cache)
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        types: [closed]
+        branches: [main]
+
+concurrency:
+    group: invalidate-mcp-cache
+    cancel-in-progress: true
+
+jobs:
+    notify:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Call webhook for MCP server
+              run: |
+                  curl -sS -X POST "${{vars.MCP_URL}}" \
+                      -H "Content-Type: application/json" \
+                      -H "${{secrets.MCP_AUTH_HEADER}}: ${{secrets.MCP_AUTH_TOKEN}}" \

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -17,6 +17,6 @@ jobs:
         steps:
             - name: Call webhook for MCP server
               run: |
-                  curl -sS -X POST "${{vars.MCP_URL}}" \
+                  curl -sS -X POST "${{vars.MCP_WEBHOOK_URL}}" \
                       -H "Content-Type: application/json" \
                       -H "${{secrets.MCP_AUTH_HEADER}}: ${{secrets.MCP_AUTH_TOKEN}}" \

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -17,6 +17,7 @@ jobs:
         steps:
             - name: Call webhook for MCP server
               run: |
-                  curl -sS -X POST "${{vars.MCP_WEBHOOK_URL}}" \
+                  curl --fail -sS -X POST "${{vars.MCP_WEBHOOK_URL}}" \
                       -H "Content-Type: application/json" \
                       -H "${{secrets.MCP_AUTH_HEADER}}: ${{secrets.MCP_AUTH_TOKEN}}" \
+                  

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -6,6 +6,7 @@ on:
     pull_request:
         types: [closed]
         branches: [main]
+    workflow_dispatch:
 
 concurrency:
     group: invalidate-mcp-cache


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate notifications to an external MCP server whenever new content is published or updated. The workflow is triggered on key repository events and uses a webhook to inform the MCP server, helping to keep external caches in sync.

**New workflow automation:**

* Added `.github/workflows/invalidate-mcp-cache.yml` to notify the MCP server via webhook when there are pushes to `main`, pull requests closed on `main`, releases published, or manual workflow dispatches.
* Configured concurrency control to prevent overlapping notifications by cancelling in-progress jobs in the same group.
* Implemented a job using `curl` to POST to the MCP webhook URL, including authentication headers from repository secrets.