### PR TITLE
ci(invalidate-mcp-cache.yml): add vars

### DIFF
--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -25,11 +25,11 @@ jobs:
           url="${{ vars.MCP_WEBHOOK_URL }}"
           header_name="${{ secrets.MCP_AUTH_HEADER }}"
           header_token="${{ secrets.MCP_AUTH_TOKEN }}"
-          max_attempts=${{ vars.MCP_WEBHOOK_RETRY_COUNT }}
+          max_attempts=${{ vars.MCP_WEBHOOK_RETRY_COUNT_MAX }}
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: POST $url"
-            if curl --fail -sS --max-time ${{ vars.WEBHOOK_MCP_TIMEOUT }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
+            if curl --fail -sS --max-time ${{ vars.WEBHOOK_MCP_TIMEOUT_MAX }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
               echo "Webhook POST succeeded"
               exit 0
             else

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -29,7 +29,7 @@ jobs:
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: POST $url"
-            if curl --fail -sS --max-time ${{ vars.WEBHOOK_MCP_TIMEOUT }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
+            if curl --fail -sS --max-time ${{ vars.MCP_WEBHOOK_TIMEOUT }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
               echo "Webhook POST succeeded"
               exit 0
             else

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -25,11 +25,11 @@ jobs:
           url="${{ vars.MCP_WEBHOOK_URL }}"
           header_name="${{ secrets.MCP_AUTH_HEADER }}"
           header_token="${{ secrets.MCP_AUTH_TOKEN }}"
-          max_attempts=5
+          max_attempts=${{ vars.MCP_RETRY_COUNT }}
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: POST $url"
-            if curl --fail -sS --max-time 5 -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
+            if curl --fail -sS --max-time ${{ vars.MCP_TIMEOUT }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
               echo "Webhook POST succeeded"
               exit 0
             else

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -25,11 +25,23 @@ jobs:
           url="${{ vars.MCP_WEBHOOK_URL }}"
           header_name="${{ secrets.MCP_AUTH_HEADER }}"
           header_token="${{ secrets.MCP_AUTH_TOKEN }}"
-          max_attempts=${{ vars.MCP_WEBHOOK_RETRY_COUNT || 5 }}
+          max_attempts="${{ vars.MCP_WEBHOOK_RETRY_COUNT }}"  
+          # Validate max_attempts: must be a positive integer, default to 5 if unset/invalid  
+          if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then  
+            echo "Warning: MCP_WEBHOOK_RETRY_COUNT is unset or invalid ('$max_attempts'). Defaulting to 5."  
+            max_attempts=5  
+          fi  
+          retry_delay="${{ vars.MCP_WEBHOOK_TIMEOUT }}"  
+          # Validate retry_delay: must be a positive integer, default to 5 if unset/invalid  
+          if ! [[ "$retry_delay" =~ ^[1-9][0-9]*$ ]]; then  
+            echo "Warning: MCP_WEBHOOK_TIMEOUT is unset or invalid ('$retry_delay'). Defaulting to 5."  
+            retry_delay=5  
+          fi 
+          
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: POST $url"
-            if curl --fail -sS --max-time ${{ vars.MCP_WEBHOOK_TIMEOUT || 5 }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
+            if curl --fail -sS --max-time $retry_delay -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
               echo "Webhook POST succeeded"
               exit 0
             else

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -25,11 +25,11 @@ jobs:
           url="${{ vars.MCP_WEBHOOK_URL }}"
           header_name="${{ secrets.MCP_AUTH_HEADER }}"
           header_token="${{ secrets.MCP_AUTH_TOKEN }}"
-          max_attempts=${{ vars.MCP_RETRY_COUNT }}
+          max_attempts=${{ vars.MCP_WEBHOOK_RETRY_COUNT }}
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: POST $url"
-            if curl --fail -sS --max-time ${{ vars.MCP_TIMEOUT }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
+            if curl --fail -sS --max-time ${{ vars.WEBHOOK_MCP_TIMEOUT }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
               echo "Webhook POST succeeded"
               exit 0
             else

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -25,11 +25,11 @@ jobs:
           url="${{ vars.MCP_WEBHOOK_URL }}"
           header_name="${{ secrets.MCP_AUTH_HEADER }}"
           header_token="${{ secrets.MCP_AUTH_TOKEN }}"
-          max_attempts=${{ vars.MCP_WEBHOOK_RETRY_COUNT_MAX }}
+          max_attempts=${{ vars.MCP_WEBHOOK_RETRY_COUNT }}
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: POST $url"
-            if curl --fail -sS --max-time ${{ vars.WEBHOOK_MCP_TIMEOUT_MAX }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
+            if curl --fail -sS --max-time ${{ vars.WEBHOOK_MCP_TIMEOUT }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
               echo "Webhook POST succeeded"
               exit 0
             else

--- a/.github/workflows/invalidate-mcp-cache.yml
+++ b/.github/workflows/invalidate-mcp-cache.yml
@@ -25,11 +25,11 @@ jobs:
           url="${{ vars.MCP_WEBHOOK_URL }}"
           header_name="${{ secrets.MCP_AUTH_HEADER }}"
           header_token="${{ secrets.MCP_AUTH_TOKEN }}"
-          max_attempts=${{ vars.MCP_WEBHOOK_RETRY_COUNT }}
+          max_attempts=${{ vars.MCP_WEBHOOK_RETRY_COUNT || 5 }}
           attempt=1
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts: POST $url"
-            if curl --fail -sS --max-time ${{ vars.MCP_WEBHOOK_TIMEOUT }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
+            if curl --fail -sS --max-time ${{ vars.MCP_WEBHOOK_TIMEOUT || 5 }} -X POST "$url" -H "Content-Type: application/json" -H "$header_name: $header_token"; then
               echo "Webhook POST succeeded"
               exit 0
             else


### PR DESCRIPTION
This pull request updates the MCP cache invalidation workflow to make its retry and timeout behavior configurable via repository variables, improving flexibility and maintainability.

Configuration improvements:

* The maximum number of webhook retry attempts is now set using the `MCP_WEBHOOK_RETRY_COUNT` repository variable instead of a hardcoded value.
* The webhook POST request timeout is now set using the `WEBHOOK_MCP_TIMEOUT` repository variable instead of a hardcoded value.