### PR TITLE
chore: add input for dotnet\test and use dotnet\test in dotnet\publish

### DIFF
--- a/.github/actions/demo-dotnet-actions/action.yml
+++ b/.github/actions/demo-dotnet-actions/action.yml
@@ -49,6 +49,28 @@ runs:
         dotnet-version: "8.0.x"
         project-regex: '.*Tests\.csproj\s*$'
 
+    - name: Run tests (specific project)
+      if: ${{ inputs.run-test-step == 'true' }}
+      uses: ./dotnet/test
+      with:
+        dotnet-version: "8.0.x"
+        project-file: src/demo/dotnet/tests/Api.Tests/Api.Tests.csproj
+
+    - name: Run tests (Should Fail)
+      id: test-fail
+      if: ${{ inputs.run-test-step == 'true' }}
+      continue-on-error: true
+      uses: ./dotnet/test
+      with:
+        dotnet-version: "8.0.x"
+
+    - name: Assert Failure of Previous
+      if: ${{ steps.test-fail.outcome != 'failure' }}
+      shell: bash
+      run: |
+        echo "Expected previous test step to fail, but it did not." >&2
+        exit 1
+
     - name: Lint
       if: ${{ inputs.run-lint-step == 'true' }}
       uses: ./dotnet/lint

--- a/dotnet/test/action.yml
+++ b/dotnet/test/action.yml
@@ -1,31 +1,52 @@
-name: 'Run Tests'
-description: 'Runs tests for a specific directory'
-author: 'Trafera'
+name: "Run Tests"
+description: "Runs tests for a specific directory"
+author: "Trafera"
 
 inputs:
   args:
-    description: 'Additional arguments to pass to dotnet test command'
+    description: "Additional arguments to pass to dotnet test command"
     required: false
-    default: '--verbosity normal'
+    default: "--verbosity normal"
   directory:
-    description: 'Directory to run tests in'
-    required: true
+    description: "Directory to run tests in (required when project-file is not provided)"
+    required: false
+    default: ""
   dotnet-version:
-    description: 'Version of .NET SDK to use'
+    description: "Version of .NET SDK to use"
     required: true
-    default: '6.0.x'
+    default: "6.0.x"
   max-depth:
-    description: 'Maximum depth to search for .sln or .csproj files.'
+    description: "Maximum depth to search for .sln or .csproj files."
     required: false
-    default: '5'
+    default: "5"
   project-regex:
-    description: 'Regular expression to identify project file desired.  If empty, will return the first .csproj file found when find-project is true.'
+    description: "Regular expression to identify project file desired.  If empty, will return the first .csproj file found when find-project is true."
     required: false
-    default: ''
+    default: ""
+  project-file:
+    description: "Path to the project file. If specified, this will be used instead of searching the directory for a .csproj or .sln file."
+    required: false
+    default: ""
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        PROJECT_FILE="${{ inputs.project-file }}"
+        DIRECTORY="${{ inputs.directory }}"
+        PROJECT_REGEX="${{ inputs.project-regex }}"
+        if [ -n "${PROJECT_FILE}" ]; then
+          echo "project-file provided: validation passed"
+          exit 0
+        fi
+        if [ -z "${DIRECTORY}" ] || [ -z "${PROJECT_REGEX}" ]; then
+          echo "Error: Provide 'project-file' or both 'directory' and 'project-regex'." >&2
+          exit 1
+        fi
+        echo "directory & project-regex provided: validation passed"
+
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v4
       with:
@@ -33,6 +54,7 @@ runs:
 
     - name: Get solution or project file
       id: get-solution-or-proj
+      if: ${{ inputs.project-file == '' }}
       uses: Now-Micro/actions/get-project-and-solution-files-from-directory@v1
       with:
         directory: ${{ inputs.directory }}
@@ -41,13 +63,26 @@ runs:
         find-solution: true
         project-regex: ${{ inputs.project-regex }}
 
+    - name: Resolve project or solution
+      id: resolve-target
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.project-file }}" ]; then
+          echo "path=${{ inputs.project-file }}" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        TARGET="${{ steps.get-solution-or-proj.outputs.project-found }}"
+        if [ -z "${TARGET}" ]; then
+          TARGET="${{ steps.get-solution-or-proj.outputs.solution-found }}"
+        fi
+        if [ -z "${TARGET}" ]; then
+          echo "Error: No project or solution discovered by get-project-and-solution-files-from-directory." >&2
+          exit 1
+        fi
+        echo "path=${TARGET}" >> "$GITHUB_OUTPUT"
+
     - name: Run tests
       shell: bash
       run: |
-        PROJECT_OR_SOLUTION=${{ steps.get-solution-or-proj.outputs.project-found || steps.get-solution-or-proj.outputs.solution-found}}
-        echo "Running: dotnet test $PROJECT_OR_SOLUTION ${{ inputs.args }}"
-        if [ -z "$PROJECT_OR_SOLUTION" ]; then
-          echo "No .sln or .csproj found in ${{ inputs.directory }}"
-          exit 1
-        fi
-        dotnet test "$PROJECT_OR_SOLUTION" ${{ inputs.args }}
+        echo "Running: dotnet test "${{ steps.resolve-target.outputs.path }}" ${{ inputs.args }}"
+        dotnet test "${{ steps.resolve-target.outputs.path }}" ${{ inputs.args }}

--- a/nuget/publish/action.yml
+++ b/nuget/publish/action.yml
@@ -107,8 +107,9 @@ runs:
 
     - name: Test
       if: ${{ inputs.test-project-file != '' }}
-      shell: bash
-      run: dotnet test --no-restore ${{ inputs.test-project-file }}
+      uses: Now-Micro/actions/dotnet/test@v1
+      with:
+        project-file: ${{ inputs.test-project-file }}
 
     - name: Publish NuGet Package
       shell: bash


### PR DESCRIPTION
This pull request enhances the flexibility and reliability of the `.NET` test GitHub Action by introducing support for directly specifying a project file, improving input validation, and updating dependent workflows to use the new features. These changes make it easier to target specific test projects and ensure correct usage of the action.

**Improvements to test action input handling:**

* Added a new `project-file` input to `dotnet/test/action.yml`, allowing users to specify the exact project file to test, bypassing directory and regex-based search. Also added validation logic to enforce correct input combinations.
* Updated the action logic to resolve the target project or solution file by prioritizing the `project-file` input if provided, and improved error handling for missing files.

**Integration and workflow updates:**

* Modified `.github/actions/demo-dotnet-actions/action.yml` to add steps for running tests on a specific project file, testing intentional failure scenarios, and asserting expected failures for improved CI reliability.
* Updated `nuget/publish/action.yml` to use the improved test action with the new `project-file` input for running tests before publishing NuGet packages.