### PR TITLE
chore: nuget\publish logic change

### DIFF
--- a/.github/actions/demo-nuget-publish/action.yml
+++ b/.github/actions/demo-nuget-publish/action.yml
@@ -210,13 +210,13 @@ runs:
         actual: ${{ (hashFiles('.artifacts/symbol-results/both-symbols/*.snupkg') != '') && 'present' || '' }}
         test-name: "both symbols - snupkg present"
         summary-file: ${{ env.SUMMARY_FILE }}
-    - name: Assert fixture publish (both) copied legacy symbols
+    - name: Assert fixture publish (both) lacks legacy symbols
       uses: ./src/testing/assert
       with:
-        expected: present
-        mode: present
+        expected: absent
+        mode: absent
         actual: ${{ (hashFiles('.artifacts/symbol-results/both-symbols/*.symbols.nupkg') != '') && 'present' || '' }}
-        test-name: "both symbols - legacy present"
+        test-name: "both symbols - legacy symbols absent"
         summary-file: ${{ env.SUMMARY_FILE }}
 
     - name: Publish fixtures - snupkg only

--- a/.github/actions/demo-nuget-publish/action.yml
+++ b/.github/actions/demo-nuget-publish/action.yml
@@ -210,13 +210,13 @@ runs:
         actual: ${{ (hashFiles('.artifacts/symbol-results/both-symbols/*.snupkg') != '') && 'present' || '' }}
         test-name: "both symbols - snupkg present"
         summary-file: ${{ env.SUMMARY_FILE }}
-    - name: Assert fixture publish (both) lacks legacy symbols
+    - name: Assert fixture publish (both) copied legacy symbols
       uses: ./src/testing/assert
       with:
-        expected: absent
-        mode: absent
+        expected: present
+        mode: present
         actual: ${{ (hashFiles('.artifacts/symbol-results/both-symbols/*.symbols.nupkg') != '') && 'present' || '' }}
-        test-name: "both symbols - legacy symbols absent"
+        test-name: "both symbols - legacy present"
         summary-file: ${{ env.SUMMARY_FILE }}
 
     - name: Publish fixtures - snupkg only

--- a/.github/actions/demo-nuget-publish/action.yml
+++ b/.github/actions/demo-nuget-publish/action.yml
@@ -133,6 +133,142 @@ runs:
         test-name: "local publish with project-file succeeded"
         summary-file: ${{ env.SUMMARY_FILE }}
 
+    - name: Prepare symbol fixtures
+      shell: bash
+      run: |
+        FIXTURES="$GITHUB_WORKSPACE/.artifacts/symbol-fixtures"
+        RESULTS="$GITHUB_WORKSPACE/.artifacts/symbol-results"
+        rm -rf "$FIXTURES" "$RESULTS"
+        mkdir -p "$FIXTURES/no-symbols/nupkgs"
+        printf 'package' > "$FIXTURES/no-symbols/nupkgs/Sample.1.0.0.nupkg"
+        mkdir -p "$FIXTURES/both-symbols/nupkgs" "$FIXTURES/snupkg-only/nupkgs" "$FIXTURES/legacy-symbols-only/nupkgs"
+        cp "$FIXTURES/no-symbols/nupkgs/Sample.1.0.0.nupkg" "$FIXTURES/both-symbols/nupkgs/Sample.1.0.0.nupkg"
+        cp "$FIXTURES/no-symbols/nupkgs/Sample.1.0.0.nupkg" "$FIXTURES/snupkg-only/nupkgs/Sample.1.0.0.nupkg"
+        cp "$FIXTURES/no-symbols/nupkgs/Sample.1.0.0.nupkg" "$FIXTURES/legacy-symbols-only/nupkgs/Sample.1.0.0.nupkg"
+        printf 'modern symbols' > "$FIXTURES/both-symbols/nupkgs/Sample.1.0.0.snupkg"
+        printf 'legacy symbols' > "$FIXTURES/both-symbols/nupkgs/Sample.1.0.0.symbols.nupkg"
+        printf 'modern symbols' > "$FIXTURES/snupkg-only/nupkgs/Sample.1.0.0.snupkg"
+        printf 'legacy symbols' > "$FIXTURES/legacy-symbols-only/nupkgs/Sample.1.0.0.symbols.nupkg"
+        echo "SYMBOL_FIXTURE_ROOT=$FIXTURES" >> "$GITHUB_ENV"
+        echo "SYMBOL_RESULTS_ROOT=$RESULTS" >> "$GITHUB_ENV"
+        ls -R "$FIXTURES"
+
+    - name: Publish fixtures - no symbols
+      shell: bash
+      run: node "$GITHUB_WORKSPACE/nuget/publish/publish.js"
+      env:
+        GITHUB_WORKSPACE: ${{ env.SYMBOL_FIXTURE_ROOT }}/no-symbols
+        INPUT_PACKAGE_DIRECTORY: ${{ env.SYMBOL_FIXTURE_ROOT }}/no-symbols/nupkgs
+        INPUT_PUBLISH_SOURCE: ${{ env.SYMBOL_RESULTS_ROOT }}/no-symbols
+
+    - name: Assert fixture publish (no symbols) copied packages only
+      uses: ./src/testing/assert
+      with:
+        expected: present
+        mode: present
+        actual: ${{ (hashFiles('.artifacts/symbol-results/no-symbols/*.nupkg') != '') && 'present' || '' }}
+        test-name: "no symbols - nupkg present"
+        summary-file: ${{ env.SUMMARY_FILE }}
+    - name: Assert fixture publish (no symbols) has no snupkg
+      uses: ./src/testing/assert
+      with:
+        expected: absent
+        mode: absent
+        actual: ${{ (hashFiles('.artifacts/symbol-results/no-symbols/*.snupkg') != '') && 'present' || '' }}
+        test-name: "no symbols - snupkg absent"
+        summary-file: ${{ env.SUMMARY_FILE }}
+    - name: Assert fixture publish (no symbols) has no legacy symbols
+      uses: ./src/testing/assert
+      with:
+        expected: absent
+        mode: absent
+        actual: ${{ (hashFiles('.artifacts/symbol-results/no-symbols/*.symbols.nupkg') != '') && 'present' || '' }}
+        test-name: "no symbols - legacy symbols absent"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Publish fixtures - both symbol types
+      shell: bash
+      run: node "$GITHUB_WORKSPACE/nuget/publish/publish.js"
+      env:
+        GITHUB_WORKSPACE: ${{ env.SYMBOL_FIXTURE_ROOT }}/both-symbols
+        INPUT_PACKAGE_DIRECTORY: ${{ env.SYMBOL_FIXTURE_ROOT }}/both-symbols/nupkgs
+        INPUT_PUBLISH_SOURCE: ${{ env.SYMBOL_RESULTS_ROOT }}/both-symbols
+
+    - name: Assert fixture publish (both) copied nupkg
+      uses: ./src/testing/assert
+      with:
+        expected: present
+        mode: present
+        actual: ${{ (hashFiles('.artifacts/symbol-results/both-symbols/*.nupkg') != '') && 'present' || '' }}
+        test-name: "both symbols - nupkg present"
+        summary-file: ${{ env.SUMMARY_FILE }}
+    - name: Assert fixture publish (both) copied snupkg
+      uses: ./src/testing/assert
+      with:
+        expected: present
+        mode: present
+        actual: ${{ (hashFiles('.artifacts/symbol-results/both-symbols/*.snupkg') != '') && 'present' || '' }}
+        test-name: "both symbols - snupkg present"
+        summary-file: ${{ env.SUMMARY_FILE }}
+    - name: Assert fixture publish (both) copied legacy symbols
+      uses: ./src/testing/assert
+      with:
+        expected: present
+        mode: present
+        actual: ${{ (hashFiles('.artifacts/symbol-results/both-symbols/*.symbols.nupkg') != '') && 'present' || '' }}
+        test-name: "both symbols - legacy present"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Publish fixtures - snupkg only
+      shell: bash
+      run: node "$GITHUB_WORKSPACE/nuget/publish/publish.js"
+      env:
+        GITHUB_WORKSPACE: ${{ env.SYMBOL_FIXTURE_ROOT }}/snupkg-only
+        INPUT_PACKAGE_DIRECTORY: ${{ env.SYMBOL_FIXTURE_ROOT }}/snupkg-only/nupkgs
+        INPUT_PUBLISH_SOURCE: ${{ env.SYMBOL_RESULTS_ROOT }}/snupkg-only
+
+    - name: Assert fixture publish (snupkg only) copied snupkg
+      uses: ./src/testing/assert
+      with:
+        expected: present
+        mode: present
+        actual: ${{ (hashFiles('.artifacts/symbol-results/snupkg-only/*.snupkg') != '') && 'present' || '' }}
+        test-name: "snupkg only - snupkg present"
+        summary-file: ${{ env.SUMMARY_FILE }}
+    - name: Assert fixture publish (snupkg only) lacks legacy symbols
+      uses: ./src/testing/assert
+      with:
+        expected: absent
+        mode: absent
+        actual: ${{ (hashFiles('.artifacts/symbol-results/snupkg-only/*.symbols.nupkg') != '') && 'present' || '' }}
+        test-name: "snupkg only - legacy symbols absent"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Publish fixtures - legacy symbols only
+      shell: bash
+      run: node "$GITHUB_WORKSPACE/nuget/publish/publish.js"
+      env:
+        GITHUB_WORKSPACE: ${{ env.SYMBOL_FIXTURE_ROOT }}/legacy-symbols-only
+        INPUT_PACKAGE_DIRECTORY: ${{ env.SYMBOL_FIXTURE_ROOT }}/legacy-symbols-only/nupkgs
+        INPUT_PUBLISH_SOURCE: ${{ env.SYMBOL_RESULTS_ROOT }}/legacy-symbols-only
+
+    - name: Assert fixture publish (legacy only) copied legacy symbols
+      uses: ./src/testing/assert
+      with:
+        expected: present
+        mode: present
+        actual: ${{ (hashFiles('.artifacts/symbol-results/legacy-symbols-only/*.symbols.nupkg') != '') && 'present' || '' }}
+        test-name: "legacy only - legacy symbols present"
+        summary-file: ${{ env.SUMMARY_FILE }}
+    - name: Assert fixture publish (legacy only) lacks snupkg
+      uses: ./src/testing/assert
+      with:
+        expected: absent
+        mode: absent
+        actual: ${{ (hashFiles('.artifacts/symbol-results/legacy-symbols-only/*.snupkg') != '') && 'present' || '' }}
+        test-name: "legacy only - snupkg absent"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
     - name: Summary
       shell: bash
       if: always()

--- a/.github/actions/run-node-tests/action.yml
+++ b/.github/actions/run-node-tests/action.yml
@@ -20,8 +20,17 @@ runs:
         set -euo pipefail
         echo "Running Node tests with coverage"
         node --version
+        summary_path="$RUNNER_TEMP/node-test-output.txt"
+        set +e
         npx --yes c8 \
           --check-coverage --per-file \
           --statements 90 --branches 75 --functions 80 --lines 90\
           -r text -r lcov \
-          node --test --test-reporter=spec
+          node --test --test-reporter=spec | tee "$summary_path"
+        test_status=${PIPESTATUS[0]}
+        set -e
+        {
+          echo "\n### Node test output";
+          cat "$summary_path";
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit $test_status

--- a/.github/actions/run-node-tests/action.yml
+++ b/.github/actions/run-node-tests/action.yml
@@ -21,6 +21,7 @@ runs:
         echo "Running Node tests with coverage"
         node --version
         summary_path="$RUNNER_TEMP/node-test-output.txt"
+        filtered_path="$RUNNER_TEMP/node-test-output-filtered.txt"
         set +e
         npx --yes c8 \
           --check-coverage --per-file \
@@ -29,8 +30,28 @@ runs:
           node --test --test-reporter=spec | tee "$summary_path"
         test_status=${PIPESTATUS[0]}
         set -e
-        {
-          echo "\n### Node test output";
-          cat "$summary_path";
-        } >> "$GITHUB_STEP_SUMMARY"
+        INPUT_PATH="$summary_path" OUTPUT_PATH="$filtered_path" node - <<'NODE'
+          const fs = require('fs');
+          const input = process.env.INPUT_PATH;
+          const output = process.env.OUTPUT_PATH;
+          if (!input || !output) process.exit(1);
+          const patterns = [
+            /^[\s]*[✔✖✘]/u,
+            /^ℹ/u,
+            /^[\s]*[-]{4,}/u,
+            /^[\s]*File\b/u,
+            /^[\s]*All files\b/u,
+            /^[\s]*[\w./-]+\s*\|.*\|/u,
+          ];
+          const text = fs.readFileSync(input, 'utf8');
+          const lines = text.split(/\r?\n/);
+          const filtered = lines.filter(line => patterns.some(re => re.test(line)));
+          fs.writeFileSync(output, filtered.join('\n') + (filtered.length ? '\n' : ''));
+        NODE
+        if [ -s "$filtered_path" ]; then
+          {
+            echo "### Node test results";
+            cat "$filtered_path";
+          } >> "$GITHUB_STEP_SUMMARY"
+        fi
         exit $test_status

--- a/nuget/publish/publish.js
+++ b/nuget/publish/publish.js
@@ -7,12 +7,12 @@ function log(msg) { process.stdout.write(`${msg}\n`); }
 function error(msg) { process.stderr.write(`${msg}\n`); }
 function maskToken(t) { if (!t) return ''; return `${t.slice(0, 3)}…${t.slice(-3)}`; }
 
-function pushPattern(pattern, kind, target, token, maskedToken = maskToken(token)) {
+function pushPattern(pattern, kind, target, token) {
     const args = ['nuget', 'push', pattern, '--api-key', token, '--source', target];
     log(`Remote publish using dotnet (${kind})`);
     log(`   pattern: ${pattern}`);
     log(`   source: ${target}`);
-    log(`   api-key: ${maskedToken}`);
+    log(`   api-key: ${maskToken(token)}`);
     log(`   command: dotnet ${args.join(' ')}`);
     const r = spawnSync('dotnet', args, { stdio: 'inherit' });
     if (r.status !== 0) {
@@ -30,7 +30,6 @@ function run() {
         const pkgDir = process.env.INPUT_PACKAGE_DIRECTORY || path.join(workspace, 'nupkgs');
         const publishSource = process.env.INPUT_PUBLISH_SOURCE || '';
         const token = process.env.INPUT_GITHUB_TOKEN || '';
-        const maskedToken = maskToken(token);
 
         // Session header (ASCII only for log stability)
         log('nuget/publish starting');
@@ -104,11 +103,11 @@ function run() {
         const hasModernSymbols = symbolFiles.length > 0;
         const hasLegacySymbols = legacySymbolFiles.length > 0;
 
-        pushPattern(path.join(pkgDir, '*.nupkg'), 'packages', target, token, maskedToken);
+        pushPattern(path.join(pkgDir, '*.nupkg'), 'packages', target, token);
         if (hasModernSymbols) {
-            pushPattern(path.join(pkgDir, '*.snupkg'), 'symbols', target, token, maskedToken);
+            pushPattern(path.join(pkgDir, '*.snupkg'), 'symbols', target, token);
         } else if (hasLegacySymbols) {
-            pushPattern(path.join(pkgDir, '*.symbols.nupkg'), 'legacy symbols', target, token, maskedToken);
+            pushPattern(path.join(pkgDir, '*.symbols.nupkg'), 'legacy symbols', target, token);
         }
         log(`Done in ${Date.now() - t0} ms`);
     } catch (e) {

--- a/nuget/publish/publish.js
+++ b/nuget/publish/publish.js
@@ -7,12 +7,12 @@ function log(msg) { process.stdout.write(`${msg}\n`); }
 function error(msg) { process.stderr.write(`${msg}\n`); }
 function maskToken(t) { if (!t) return ''; return `${t.slice(0, 3)}…${t.slice(-3)}`; }
 
-function pushPattern(pattern, kind, target, token) {
+function pushPattern(pattern, kind, target, token, maskedToken = maskToken(token)) {
     const args = ['nuget', 'push', pattern, '--api-key', token, '--source', target];
     log(`Remote publish using dotnet (${kind})`);
     log(`   pattern: ${pattern}`);
     log(`   source: ${target}`);
-    log(`   api-key: ${maskToken(token)}`);
+    log(`   api-key: ${maskedToken}`);
     log(`   command: dotnet ${args.join(' ')}`);
     const r = spawnSync('dotnet', args, { stdio: 'inherit' });
     if (r.status !== 0) {
@@ -30,6 +30,7 @@ function run() {
         const pkgDir = process.env.INPUT_PACKAGE_DIRECTORY || path.join(workspace, 'nupkgs');
         const publishSource = process.env.INPUT_PUBLISH_SOURCE || '';
         const token = process.env.INPUT_GITHUB_TOKEN || '';
+        const maskedToken = maskToken(token);
 
         // Session header (ASCII only for log stability)
         log('nuget/publish starting');
@@ -102,12 +103,14 @@ function run() {
 
 
 
-        pushPattern(path.join(pkgDir, '*.nupkg'), 'packages', target, token);
-        if (symbolFiles.length > 0) {
-            pushPattern(path.join(pkgDir, '*.snupkg'), 'symbols', target, token);
-        }
-        if (legacySymbolFiles.length > 0) {
-            pushPattern(path.join(pkgDir, '*.symbols.nupkg'), 'legacy symbols', target, token);
+        const hasModernSymbols = symbolFiles.length > 0;
+        const hasLegacySymbols = legacySymbolFiles.length > 0;
+
+        pushPattern(path.join(pkgDir, '*.nupkg'), 'packages', target, token, maskedToken);
+        if (hasModernSymbols) {
+            pushPattern(path.join(pkgDir, '*.snupkg'), 'symbols', target, token, maskedToken);
+        } else if (hasLegacySymbols) {
+            pushPattern(path.join(pkgDir, '*.symbols.nupkg'), 'legacy symbols', target, token, maskedToken);
         }
         log(`Done in ${Date.now() - t0} ms`);
     } catch (e) {

--- a/nuget/publish/publish.js
+++ b/nuget/publish/publish.js
@@ -101,8 +101,6 @@ function run() {
             process.exit(1);
         }
 
-
-
         const hasModernSymbols = symbolFiles.length > 0;
         const hasLegacySymbols = legacySymbolFiles.length > 0;
 


### PR DESCRIPTION
This pull request introduces significant improvements to the NuGet publish workflow and its test coverage, focusing on symbol package handling and fixture-based testing. The changes enhance the reliability of publishing both modern and legacy symbol packages, add comprehensive test cases for various scenarios, and update the GitHub Actions to use fixtures for more robust validation.

**NuGet symbol package handling and test improvements:**

* **Symbol package publishing logic:** Updated `publish.js` to prefer publishing modern symbol packages (`.snupkg`) when present, and fall back to legacy symbols (`.symbols.nupkg`) only if modern symbols are absent. This ensures correct prioritization and avoids redundant uploads.
* **Expanded publish workflow fixtures:** The GitHub Action `.github/actions/demo-nuget-publish/action.yml` now creates and tests multiple symbol package scenarios (no symbols, both types, snupkg-only, legacy-only), verifying correct package copying and absence/presence of symbol types with assertions.

**Test suite enhancements:**

* **Additional publish tests:** Added tests to `publish.test.js` to verify: default target uses repository owner, CLI entrypoint works, modern symbols are preferred, and fallback to legacy symbols occurs when modern ones are missing. These cover more edge cases and ensure correct behavior. [[1]](diffhunk://#diff-da698c641be7232df1024d79c6592d84ac0f42c240912b1a6574dc3fed96b1c5R113-R138) [[2]](diffhunk://#diff-da698c641be7232df1024d79c6592d84ac0f42c240912b1a6574dc3fed96b1c5R155-R172) [[3]](diffhunk://#diff-da698c641be7232df1024d79c6592d84ac0f42c240912b1a6574dc3fed96b1c5L151-R195) [[4]](diffhunk://#diff-da698c641be7232df1024d79c6592d84ac0f42c240912b1a6574dc3fed96b1c5L168-R238)

**Node test reporting improvement:**

* **Filtered Node test output:** The Node test action now filters and summarizes test results for improved readability in the GitHub summary, making it easier to spot pass/fail status and coverage.