### PR TITLE
chore: update the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # GitHub Actions Monorepo
 
-This repository serves ## Creating New Actions
+This repository serves as a centralized source for reusable GitHub Actions across the organization. It contains a collection of custom composite actions designed for high signal, low dependency workflows. Actions are built with deterministic behavior, comprehensive testing, and minimal external dependencies.
+
+## Creating New Actions
 
 To add a new reusable action:
 
@@ -20,7 +22,6 @@ To add a new reusable action:
 
 Ensure the action is self-contained, with no external dependencies beyond Node.js standard library.
 
-This repository serves as a centralized source for reusable GitHub Actions across the organization. It contains a collection of custom composite actions designed for high signal, low dependency workflows. Actions are built with deterministic behavior, comprehensive testing, and minimal external dependencies.
 ## Prerequisites
 
 - Node.js 20.x (matches the default version in the `setup-node` action).
@@ -100,7 +101,7 @@ Releases are managed via the `release.yml` workflow, which creates GitHub releas
    - **Target**: Commitish (branch or SHA; defaults to `main`).
    - **Draft/Prerelease**: Mark as draft or prerelease.
    - **Generate Release Notes**: Auto-generate from PRs/commits.
-   - **Should Delete Current**: Delete existing release/tag if it exists.
+   - **Should Delete Existing Release/Tag**: Delete existing release/tag if it exists.
    - **Skip Tests**: Skip running tests (default: true for faster releases).
 
 The workflow runs tests, creates or updates the release, and provides outputs like `release_id`, `html_url`, and `upload_url` for further automation.
@@ -109,7 +110,7 @@ The workflow runs tests, creates or updates the release, and provides outputs li
 - Use simple versioning (e.g., `v1`, `v2`, `v3`, ...).
 - Tag releases after merging changes to `main`.
 - Enable auto-generated notes for changelog summaries.
-- If updating an action, ensure backward compatibility or bump major version.
+- If updating an action, ensure backward compatibility or bump version.
 
 ## Conventions
 
@@ -132,6 +133,18 @@ The workflow runs tests, creates or updates the release, and provides outputs li
 - **Test failures**: Check coverage gaps; add scenarios for untested paths.
 
 If issues persist, review action-specific READMEs or test files for examples.
+
+## Demo Workflows and Testing
+
+This repository includes demo workflows and testing actions to validate and showcase the actions.
+
+### Demo Workflows
+
+Demo workflows are located in `.github/workflows/` and demonstrate practical usage of the actions in CI/CD pipelines. They serve as examples for consumers and are built following the guidelines in `.github/instructions/demo-workflows.md`. Each demo workflow tests specific action functionality and can be used as a starting point for integration.
+
+### Node Tests Workflow
+
+The `run-node-tests` action (in `.github/actions/run-node-tests/`) is a composite action designed for running Node.js tests in CI environments. It handles test execution, coverage reporting, and failure handling across different Node.js versions and environments.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ To add a new reusable action:
 5. **Handle inputs/outputs**: Read from `process.env.INPUT_*`, write to `process.env.GITHUB_OUTPUT`.
 6. **Test locally**: Run `node --test my-new-action/*.test.js` and check coverage with `npx c8 -r text node --test`.
 
-Ensure the action is self-contained, with no external dependencies beyond Node.js standard library.ralized source for reusable GitHub Actions across the organization. It contains a collection of custom composite actions designed for high signal, low dependency workflows. Actions are built with deterministic behavior, comprehensive testing, and minimal external dependencies.
+Ensure the action is self-contained, with no external dependencies beyond Node.js standard library.
 
+This repository serves as a centralized source for reusable GitHub Actions across the organization. It contains a collection of custom composite actions designed for high signal, low dependency workflows. Actions are built with deterministic behavior, comprehensive testing, and minimal external dependencies.
 ## Prerequisites
 
 - Node.js 20.x (matches the default version in the `setup-node` action).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,30 @@
 # GitHub Actions Monorepo
 
+This repository serves ## Creating New Actions
+
+To add a new reusable action:
+
+1. **Create the action folder**: `mkdir my-new-action/`
+2. **Write `action.yml`**: Define it as a composite action. Avoid inline logic; call your JS file:
+   ```yaml
+   runs:
+     using: 'composite'
+     steps:
+       - run: node "$GITHUB_ACTION_PATH/my-new-action.js"
+         shell: bash
+   ```
+3. **Implement the JS file**: `my-new-action.js` with exported functions and a `run()` entry point.
+4. **Add tests**: `my-new-action.test.js` covering success, error, and edge cases. Use mocks for filesystem/git/network. Aim for 100% line/branch coverage.
+5. **Handle inputs/outputs**: Read from `process.env.INPUT_*`, write to `process.env.GITHUB_OUTPUT`.
+6. **Test locally**: Run `node --test my-new-action/*.test.js` and check coverage with `npx c8 -r text node --test`.
+
+Ensure the action is self-contained, with no external dependencies beyond Node.js standard library.ralized source for reusable GitHub Actions across the organization. It contains a collection of custom composite actions designed for high signal, low dependency workflows. Actions are built with deterministic behavior, comprehensive testing, and minimal external dependencies.
+
+## Prerequisites
+
+- Node.js 20.x (matches the default version in the `setup-node` action).
+- Git for local development and testing.
+
 ## Action Structure Pattern
 Each action follows a consistent pattern:
 
@@ -17,31 +42,15 @@ Example mapping (from `get-project-and-solution-files-from-directory`):
 - Tests exercise edge cases (depth limits, multiple matches, invalid input) for 100% coverage.
 
 ## Running Tests Locally
-Prerequisites: Node.js 20.x (the repo action `setup-node` also defaults to 20.x).
 
-From the repository root (PowerShell):
+From the repo root:
 
-Run all tests:
-```
-node --test
-```
+- **Run all tests**: `node --test`
+- **Run specific tests**: `node --test get-changed-files/*.test.js`
+- **Coverage**: `npx --yes c8 -r text -r lcov node --test`
+- **Fail fast**: `node --test --test-reporter tap | Select-String -NotMatch "ok" | Select-String -Pattern "not ok"`
 
-Run tests in a single action folder:
-```
-node --test get-changed-files/*.test.js
-```
-
-Show coverage (uses `c8` – install once globally or use npx):
-```
-npx --yes c8 -r text -r lcov node --test
-```
-The `lcov` report (`coverage/lcov.info`) can be consumed by coverage services.
-
-Fail fast on first failure:
-```
-node --test --test-reporter tap | Select-String -NotMatch "ok" | Select-String -Pattern "not ok"
-```
-(Or rely on default non‑zero exit code.)
+Tests validate edge cases like invalid inputs, depth limits, and filesystem interactions.
 
 ## Adding a New Action
 1. Create a folder: `my-new-action/`.
@@ -53,16 +62,78 @@ node --test --test-reporter tap | Select-String -NotMatch "ok" | Select-String -
 6. Write outputs to `process.env.GITHUB_OUTPUT`.
 7. Run `node --test` and ensure coverage shows all lines executed (via `npx c8 ...`).
 
+## Using the Created Actions
+
+To use an action from this repo in your workflow:
+
+1. **Reference the action**: Use the full path or a local reference if in the same repo.
+   ```yaml
+   - uses: Now-Micro/actions/get-changed-files@v1  # For version 1
+   - uses: ./get-changed-files  # If using locally in this repo (e.g. in a demo file)
+   ```
+2. **Provide inputs**: Pass parameters as defined in the action's `action.yml`.
+   ```yaml
+   with:
+     head-ref: ${{ github.head_ref }}
+     base-ref: main
+   ```
+3. **Consume outputs**: Access results in subsequent steps.
+   ```yaml
+   - run: echo "Changed files: ${{ steps.my-step.outputs.changed_files }}"
+   ```
+
+Check each action's `action.yml` or README for specific inputs, outputs, and usage examples. Actions are designed for reliability in CI/CD pipelines.
+
+## Releasing a New Version
+
+Releases are managed via the `release.yml` workflow, which creates GitHub releases for tagging action versions.
+
+### Triggering a Release
+
+1. Go to the **Actions** tab in this repo.
+2. Select the **Release** workflow.
+3. Click **Run workflow** and fill in the inputs:
+   - **Tag**: The version tag (e.g., `v2`).
+   - **Name**: Release name (defaults to the tag if empty).
+   - **Body**: Release notes (ignored if auto-generating notes).
+   - **Target**: Commitish (branch or SHA; defaults to `main`).
+   - **Draft/Prerelease**: Mark as draft or prerelease.
+   - **Generate Release Notes**: Auto-generate from PRs/commits.
+   - **Should Delete Current**: Delete existing release/tag if it exists.
+   - **Skip Tests**: Skip running tests (default: true for faster releases).
+
+The workflow runs tests, creates or updates the release, and provides outputs like `release_id`, `html_url`, and `upload_url` for further automation.
+
+### Best Practices
+- Use simple versioning (e.g., `v1`, `v2`, `v3`, ...).
+- Tag releases after merging changes to `main`.
+- Enable auto-generated notes for changelog summaries.
+- If updating an action, ensure backward compatibility or bump major version.
+
 ## Conventions
-- No external test frameworks (keep dependencies zero for speed & simplicity).
-- Prefer small pure functions that are exported and directly testable.
-- Keep side effects (filesystem, git, network) isolated for easier mocking.
-- Log with concise, user‑friendly messages (emoji optional) – tests should assert behavior via outputs rather than fragile log strings unless validating error paths.
+
+- **Testing**: Use built-in `node:test` only; no external frameworks. Export pure functions for direct testing. Mock side effects (e.g., filesystem, git commands).
+- **Inputs/Outputs**: Env-based for JS; document clearly in `action.yml`.
+- **Logging**: Concise, user-friendly messages. Tests assert outputs, not logs (except errors).
+- **Dependencies**: Zero external NPM deps to keep actions lightweight.
+- **Paths**: Use `path.join` for cross-platform; forward slashes for Git commands.
+- **Error Handling**: Exit with code 1 on errors; provide clear messages.
+- **Coverage**: Target 100% line/branch coverage; use `c8` for reporting.
 
 ## Troubleshooting
-- Missing outputs: ensure `GITHUB_OUTPUT` is set in tests; mimic existing test harnesses.
-- Windows path issues: prefer forward slashes only when interacting with Git commands; use `path.join` elsewhere.
-- Depth logic: remember `currentDepth > maxDepth` guard; tests should cover boundary (`maxDepth` exactly meets the target directory).
+
+- **Missing outputs**: Ensure `GITHUB_OUTPUT` is set in tests; mimic existing harnesses.
+- **Windows paths**: Use `path.join` for local paths; forward slashes for Git.
+- **Depth logic**: Guard with `currentDepth > maxDepth`; test boundaries.
+- **Git commands**: Handle errors from `execSync`; test with mocked repos.
+- **Regex patterns**: Validate in ignore parameters; test invalid patterns.
+- **Permissions**: Ensure workflows have `contents: write` for releases.
+- **Test failures**: Check coverage gaps; add scenarios for untested paths.
+
+If issues persist, review action-specific READMEs or test files for examples.
 
 ## Notes
-These actions have only been tested on Linux runners.
+
+- Actions are tested on Linux runners; Windows/macOS may have path differences.
+- For local scripts (e.g., `clean-up-git-branches.ps1`), see inline comments for usage.
+- Contributions: Follow the pattern; add tests first; update this README if adding new sections.


### PR DESCRIPTION
This pull request significantly improves the `README.md` documentation for the GitHub Actions monorepo. The updates provide clear, step-by-step instructions for creating, testing, using, and releasing new actions, as well as best practices and troubleshooting guidance. The changes make it much easier for contributors to understand the workflow for adding and maintaining actions in the repository.

**Documentation improvements:**

* Added a comprehensive "Creating New Actions" section detailing the folder structure, implementation guidelines, testing requirements, and input/output handling for new actions.
* Expanded instructions for running tests locally, including commands for full runs, targeted tests, coverage reporting, and fail-fast options.

**Usage and release workflow:**

* Introduced a "Using the Created Actions" section with examples for referencing actions in workflows, passing inputs, and consuming outputs.
* Added a detailed "Releasing a New Version" section explaining how to trigger releases via the workflow, including best practices for versioning and changelog generation.

**Conventions and troubleshooting:**

* Updated and clarified conventions for testing, inputs/outputs, logging, dependencies, path handling, error management, and coverage expectations.
* Enhanced troubleshooting notes to cover common issues with outputs, paths, depth logic, git commands, regex patterns, permissions, and test failures.