### PR TITLE
refactor: dotnet/install

### DIFF
--- a/.github/workflows/demo-nuget-configure-source.yml
+++ b/.github/workflows/demo-nuget-configure-source.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 

--- a/dotnet/coding-standards/action.yml
+++ b/dotnet/coding-standards/action.yml
@@ -39,7 +39,7 @@ runs:
       uses: Now-Micro/actions/setup-node@v1
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
 
     - name: Get Project and Solution Files
       id: get-project-and-solution-files

--- a/dotnet/install/action.yml
+++ b/dotnet/install/action.yml
@@ -1,5 +1,5 @@
 name: "Run .NET Tests (dotnet-test)"
-description: "Installs one or more .NET SDKs using the dotnet install script."
+description: "Installs one or more .NET SDKs using actions/setup-dotnet."
 author: "Now-Micro"
 inputs:
   dotnet-version:
@@ -13,9 +13,39 @@ runs:
     - name: Setup Node.js
       uses: Now-Micro/actions/setup-node@v1
 
-    - name: Install SDK(s)
-      id: dotnet-install
+    - name: Parse SDK versions
+      id: parse_versions
       shell: bash
       run: node "$GITHUB_ACTION_PATH/dotnet-install.js"
       env:
         INPUT_DOTNET_VERSION: ${{ inputs.dotnet-version }}
+
+    - name: Install SDK 1
+      if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 1 }}
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: ${{ steps.parse_versions.outputs.version_1 }}
+
+    - name: Install SDK 2
+      if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 2 }}
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: ${{ steps.parse_versions.outputs.version_2 }}
+
+    - name: Install SDK 3
+      if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 3 }}
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: ${{ steps.parse_versions.outputs.version_3 }}
+
+    - name: Install SDK 4
+      if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 4 }}
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: ${{ steps.parse_versions.outputs.version_4 }}
+
+    - name: Install SDK 5
+      if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 5 }}
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: ${{ steps.parse_versions.outputs.version_5 }}

--- a/dotnet/install/action.yml
+++ b/dotnet/install/action.yml
@@ -22,30 +22,30 @@ runs:
 
     - name: Install SDK 1
       if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 1 }}
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ steps.parse_versions.outputs.version_1 }}
 
     - name: Install SDK 2
       if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 2 }}
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ steps.parse_versions.outputs.version_2 }}
 
     - name: Install SDK 3
       if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 3 }}
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ steps.parse_versions.outputs.version_3 }}
 
     - name: Install SDK 4
       if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 4 }}
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ steps.parse_versions.outputs.version_4 }}
 
     - name: Install SDK 5
       if: ${{ fromJSON(steps.parse_versions.outputs.version_count) >= 5 }}
-      uses: actions/setup-dotnet@v6
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ steps.parse_versions.outputs.version_5 }}

--- a/dotnet/install/dotnet-install.js
+++ b/dotnet/install/dotnet-install.js
@@ -1,5 +1,9 @@
 const fs = require('fs');
 
+function isDebugEnabled() {
+    return /^(true|1|yes|on)$/i.test(process.env.INPUT_DEBUG_MODE || '');
+}
+
 function parseVersions(input) {
     if (!input) return [];
     return input.split(',').map(s => s.trim()).filter(Boolean);
@@ -23,16 +27,25 @@ function run() {
         process.exit(1);
     }
 
+    const newlineVersion = versions.find(version => /[\r\n]/.test(version));
+    if (newlineVersion) {
+        console.error(`Invalid .NET version contains a newline: ${JSON.stringify(newlineVersion)}`);
+        process.exit(1);
+    }
+
     const ghOutput = process.env.GITHUB_OUTPUT;
     if (!ghOutput) {
         console.error('GITHUB_OUTPUT not set');
         process.exit(1);
     }
 
+    const debugEnabled = isDebugEnabled();
     const lines = [`version_count=${versions.length}`];
     versions.forEach((version, index) => {
         lines.push(`version_${index + 1}=${version}`);
-        console.log(`Resolved .NET SDK ${index + 1}: ${version}`);
+        if (debugEnabled) {
+            console.log(`Resolved .NET SDK ${index + 1}: ${version}`);
+        }
     });
 
     fs.appendFileSync(ghOutput, `${lines.join('\n')}\n`);
@@ -40,4 +53,4 @@ function run() {
 
 if (require.main === module) run();
 
-module.exports = { run, parseVersions };
+module.exports = { run, parseVersions, isDebugEnabled };

--- a/dotnet/install/dotnet-install.js
+++ b/dotnet/install/dotnet-install.js
@@ -1,11 +1,4 @@
 const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const child = require('child_process');
-
-// Allow tests to inject a fake execSync
-let _execSync = child.execSync;
-function __setExecSync(fn) { _execSync = fn; }
 
 function parseVersions(input) {
     if (!input) return [];
@@ -25,54 +18,26 @@ function run() {
         process.exit(1);
     }
 
-    const installDir = path.join(process.env.HOME || os.homedir(), '.dotnet');
-    try {
-        fs.mkdirSync(installDir, { recursive: true });
-    } catch (e) {
-        console.error('Failed creating install dir:', e.message);
+    if (versions.length > 5) {
+        console.error(`Too many .NET versions provided (${versions.length}); maximum supported is 5.`);
         process.exit(1);
     }
 
-    // create temporary dir for installer
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dotnet-install-'));
-    try {
-        // download installer once
-        const installer = path.join(tmp, 'dotnet-install.sh');
-        console.log(`Downloading dotnet-install to ${installer}`);
-        try {
-            _execSync(`curl -fsSL https://dot.net/v1/dotnet-install.sh -o "${installer}"`, { stdio: 'inherit' });
-            _execSync(`chmod +x "${installer}"`, { stdio: 'inherit' });
-        } catch (e) {
-            console.error('Failed to download dotnet-install script:', e && e.message ? e.message : e);
-            process.exit(1);
-        }
-
-        for (const rawv of versions) {
-            const ver = rawv.trim();
-            if (!ver) continue;
-            console.log(`Installing .NET SDK: ${ver}`);
-            if (ver.endsWith('.x')) {
-                const channel = ver.replace(/\.x$/, '');
-                console.log(`Using channel install for ${channel}`);
-                _execSync(`bash "${installer}" --channel "${channel}" --install-dir "${installDir}"`, { stdio: 'inherit' });
-            } else {
-                _execSync(`bash "${installer}" --version "${ver}" --install-dir "${installDir}"`, { stdio: 'inherit' });
-            }
-        }
-
-        // expose install dir to remaining steps
-        const ghPath = process.env.GITHUB_PATH;
-        if (!ghPath) {
-            console.error('GITHUB_PATH not set');
-            process.exit(1);
-        }
-        fs.appendFileSync(ghPath, `${installDir}\n`);
-    } finally {
-        // cleanup temp dir
-        try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (e) { /* ignore */ }
+    const ghOutput = process.env.GITHUB_OUTPUT;
+    if (!ghOutput) {
+        console.error('GITHUB_OUTPUT not set');
+        process.exit(1);
     }
+
+    const lines = [`version_count=${versions.length}`];
+    versions.forEach((version, index) => {
+        lines.push(`version_${index + 1}=${version}`);
+        console.log(`Resolved .NET SDK ${index + 1}: ${version}`);
+    });
+
+    fs.appendFileSync(ghOutput, `${lines.join('\n')}\n`);
 }
 
 if (require.main === module) run();
 
-module.exports = { run, __setExecSync };
+module.exports = { run, parseVersions };

--- a/dotnet/install/dotnet-install.test.js
+++ b/dotnet/install/dotnet-install.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { run, parseVersions } = require('./dotnet-install');
+const { run, parseVersions, isDebugEnabled } = require('./dotnet-install');
 
 function withEnv(env, fn) {
     const prev = { ...process.env };
@@ -52,6 +52,18 @@ test('parseVersions returns an empty array for falsy input', () => {
     assert.deepStrictEqual(parseVersions(undefined), []);
 });
 
+test('isDebugEnabled recognizes common truthy values', () => {
+    withEnv({ INPUT_DEBUG_MODE: 'true' }, () => {
+        assert.strictEqual(isDebugEnabled(), true);
+    });
+    withEnv({ INPUT_DEBUG_MODE: '1' }, () => {
+        assert.strictEqual(isDebugEnabled(), true);
+    });
+    withEnv({ INPUT_DEBUG_MODE: 'false' }, () => {
+        assert.strictEqual(isDebugEnabled(), false);
+    });
+});
+
 test('errors when INPUT_DOTNET_VERSION missing', () => {
     const { ghOutput } = createOutputFile();
     const code = captureExit(() => withEnv({ GITHUB_OUTPUT: ghOutput }, () => run()));
@@ -67,6 +79,39 @@ test('writes parsed versions to GITHUB_OUTPUT', () => {
     assert.match(content, /version_count=2/);
     assert.match(content, /version_1=8\.0\.x/);
     assert.match(content, /version_2=10\.0\.x/);
+});
+
+test('does not log resolved versions when debug mode is disabled', () => {
+    const { ghOutput } = createOutputFile();
+    const logged = [];
+    const originalLog = console.log;
+    console.log = (...args) => logged.push(args.join(' '));
+
+    try {
+        withEnv({ INPUT_DOTNET_VERSION: '8.0.x,10.0.x', GITHUB_OUTPUT: ghOutput }, () => run());
+    } finally {
+        console.log = originalLog;
+    }
+
+    assert.deepStrictEqual(logged, []);
+});
+
+test('logs resolved versions when debug mode is enabled', () => {
+    const { ghOutput } = createOutputFile();
+    const logged = [];
+    const originalLog = console.log;
+    console.log = (...args) => logged.push(args.join(' '));
+
+    try {
+        withEnv({ INPUT_DOTNET_VERSION: '8.0.x,10.0.x', INPUT_DEBUG_MODE: 'true', GITHUB_OUTPUT: ghOutput }, () => run());
+    } finally {
+        console.log = originalLog;
+    }
+
+    assert.deepStrictEqual(logged, [
+        'Resolved .NET SDK 1: 8.0.x',
+        'Resolved .NET SDK 2: 10.0.x',
+    ]);
 });
 
 test('runs as a CLI and writes parsed versions to GITHUB_OUTPUT', () => {
@@ -97,6 +142,20 @@ test('errors when more than five versions are provided', () => {
     const { ghOutput } = createOutputFile();
     const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '1,2,3,4,5,6', GITHUB_OUTPUT: ghOutput }, () => run()));
     assert.strictEqual(code, 1);
+});
+
+test('errors when a parsed version contains a newline', () => {
+    const { ghOutput } = createOutputFile();
+    const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '8.0.x,10.0.x\ninjected', GITHUB_OUTPUT: ghOutput }, () => run()));
+    assert.strictEqual(code, 1);
+    assert.strictEqual(fs.readFileSync(ghOutput, 'utf8'), '');
+});
+
+test('errors when a parsed version contains a carriage return', () => {
+    const { ghOutput } = createOutputFile();
+    const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '8.0.x,10.0.x\rinjected', GITHUB_OUTPUT: ghOutput }, () => run()));
+    assert.strictEqual(code, 1);
+    assert.strictEqual(fs.readFileSync(ghOutput, 'utf8'), '');
 });
 
 test('errors when GITHUB_OUTPUT is not set', () => {

--- a/dotnet/install/dotnet-install.test.js
+++ b/dotnet/install/dotnet-install.test.js
@@ -1,200 +1,113 @@
 const test = require('node:test');
 const assert = require('node:assert');
+const childProcess = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { run, __setExecSync } = require('./dotnet-install');
+const { run, parseVersions } = require('./dotnet-install');
 
 function withEnv(env, fn) {
     const prev = { ...process.env };
     Object.assign(process.env, env);
-    try { return fn(); } finally { process.env = prev; }
+    try {
+        return fn();
+    } finally {
+        process.env = prev;
+    }
 }
 
 function captureExit(fn) {
     const origExit = process.exit;
     let code;
-    process.exit = c => { code = c || 0; throw new Error(`__EXIT_${code}__`); };
-    try { fn(); } catch (e) { if (!/^__EXIT_/.test(e.message)) throw e; }
-    finally { process.exit = origExit; }
+    process.exit = c => {
+        code = c || 0;
+        throw new Error(`__EXIT_${code}__`);
+    };
+    try {
+        fn();
+    } catch (error) {
+        if (!/^__EXIT_/.test(error.message)) {
+            throw error;
+        }
+    } finally {
+        process.exit = origExit;
+    }
     return code;
 }
 
+function createOutputFile() {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
+    const ghOutput = path.join(tmp, 'out');
+    fs.writeFileSync(ghOutput, '');
+    return { tmp, ghOutput };
+}
+
+test('parseVersions trims values and skips blanks', () => {
+    assert.deepStrictEqual(parseVersions(' 8.0.x, , 10.0.x , '), ['8.0.x', '10.0.x']);
+});
+
+test('parseVersions returns an empty array for falsy input', () => {
+    assert.deepStrictEqual(parseVersions(''), []);
+    assert.deepStrictEqual(parseVersions(undefined), []);
+});
+
 test('errors when INPUT_DOTNET_VERSION missing', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    const code = captureExit(() => withEnv({ GITHUB_PATH: ghPath }, () => run()));
+    const { ghOutput } = createOutputFile();
+    const code = captureExit(() => withEnv({ GITHUB_OUTPUT: ghOutput }, () => run()));
     assert.strictEqual(code, 1);
 });
 
-test('installs versions and appends to GITHUB_PATH', () => {
-    const called = [];
-    __setExecSync((cmd, opts) => {
-        called.push(cmd);
-        return Buffer.from('ok');
+test('writes parsed versions to GITHUB_OUTPUT', () => {
+    const { ghOutput } = createOutputFile();
+
+    withEnv({ INPUT_DOTNET_VERSION: '8.0.x,10.0.x', GITHUB_OUTPUT: ghOutput }, () => run());
+
+    const content = fs.readFileSync(ghOutput, 'utf8');
+    assert.match(content, /version_count=2/);
+    assert.match(content, /version_1=8\.0\.x/);
+    assert.match(content, /version_2=10\.0\.x/);
+});
+
+test('runs as a CLI and writes parsed versions to GITHUB_OUTPUT', () => {
+    const { ghOutput } = createOutputFile();
+    childProcess.execFileSync(process.execPath, [path.join(__dirname, 'dotnet-install.js')], {
+        env: {
+            ...process.env,
+            INPUT_DOTNET_VERSION: '6.0.x,7.0.x,8.0.x',
+            GITHUB_OUTPUT: ghOutput,
+        },
+        stdio: 'pipe',
     });
 
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-
-    withEnv({ INPUT_DOTNET_VERSION: '6.0.x,7.0.100', GITHUB_PATH: ghPath, HOME: tmp }, () => run());
-
-    const content = fs.readFileSync(ghPath, 'utf8');
-    assert.ok(content.includes('.dotnet'));
-    // check that installer was downloaded and both installs invoked
-    assert.ok(called.some(c => c.includes('dotnet-install.sh')));
-    assert.ok(called.some(c => c.includes('--channel')));
-    assert.ok(called.some(c => c.includes('--version')));
+    const content = fs.readFileSync(ghOutput, 'utf8');
+    assert.match(content, /version_count=3/);
+    assert.match(content, /version_1=6\.0\.x/);
+    assert.match(content, /version_2=7\.0\.x/);
+    assert.match(content, /version_3=8\.0\.x/);
 });
 
-test('cleans up temp directory', () => {
-    // Use a real exec that just returns but create a temp dir inside run and ensure it's removed
-    __setExecSync(() => Buffer.from('ok'));
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    // run and capture tmp dirs created beneath os.tmpdir()
-    const before = fs.readdirSync(os.tmpdir()).filter(n => n.startsWith('dotnet-install-'));
-    withEnv({ INPUT_DOTNET_VERSION: '6.0.x', GITHUB_PATH: ghPath, HOME: tmp }, () => run());
-    const after = fs.readdirSync(os.tmpdir()).filter(n => n.startsWith('dotnet-install-'));
-    // there should be no new lingering dotnet-install- folders (best-effort)
-    assert.ok(after.length <= before.length);
-});
-
-test('errors when no versions parsed (empty string after trim)', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '  ,  , ', GITHUB_PATH: ghPath }, () => run()));
+test('errors when no versions parsed', () => {
+    const { ghOutput } = createOutputFile();
+    const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '  ,  , ', GITHUB_OUTPUT: ghOutput }, () => run()));
     assert.strictEqual(code, 1);
 });
 
-test('errors when install dir creation fails', () => {
-    __setExecSync(() => Buffer.from('ok'));
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    // create a file at the install dir path to cause mkdir to fail
-    const badInstallDir = path.join(tmp, '.dotnet');
-    fs.writeFileSync(badInstallDir, 'blocking file');
-    const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '6.0.x', GITHUB_PATH: ghPath, HOME: tmp }, () => run()));
+test('errors when more than five versions are provided', () => {
+    const { ghOutput } = createOutputFile();
+    const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '1,2,3,4,5,6', GITHUB_OUTPUT: ghOutput }, () => run()));
     assert.strictEqual(code, 1);
 });
 
-test('errors when installer download fails', () => {
-    __setExecSync((cmd) => {
-        if (cmd.includes('curl')) {
-            throw new Error('curl failed');
-        }
-        return Buffer.from('ok');
-    });
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '6.0.x', GITHUB_PATH: ghPath, HOME: tmp }, () => run()));
-    assert.strictEqual(code, 1);
-});
-
-test('errors when GITHUB_PATH not set', () => {
-    __setExecSync(() => Buffer.from('ok'));
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    // Save and explicitly delete GITHUB_PATH to test missing env var
-    const savedPath = process.env.GITHUB_PATH;
-    delete process.env.GITHUB_PATH;
+test('errors when GITHUB_OUTPUT is not set', () => {
+    const savedOutput = process.env.GITHUB_OUTPUT;
+    delete process.env.GITHUB_OUTPUT;
     try {
-        const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '6.0.x', HOME: tmp }, () => run()));
+        const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '8.0.x' }, () => run()));
         assert.strictEqual(code, 1);
     } finally {
-        if (savedPath !== undefined) process.env.GITHUB_PATH = savedPath;
-    }
-});
-
-test('uses os.homedir() when HOME not set', () => {
-    const called = [];
-    __setExecSync((cmd) => {
-        called.push(cmd);
-        return Buffer.from('ok');
-    });
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    // Don't set HOME, so code falls back to os.homedir()
-    const env = { INPUT_DOTNET_VERSION: '8.0.100', GITHUB_PATH: ghPath };
-    delete env.HOME;
-    withEnv(env, () => run());
-    const content = fs.readFileSync(ghPath, 'utf8');
-    assert.ok(content.includes('.dotnet'));
-});
-
-test('installs exact version (non-.x version)', () => {
-    const called = [];
-    __setExecSync((cmd) => {
-        called.push(cmd);
-        return Buffer.from('ok');
-    });
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    withEnv({ INPUT_DOTNET_VERSION: '8.0.100', GITHUB_PATH: ghPath, HOME: tmp }, () => run());
-    // Verify the --version flag was used (not --channel)
-    assert.ok(called.some(c => c.includes('--version') && c.includes('8.0.100')));
-    assert.ok(!called.some(c => c.includes('--channel')));
-});
-
-test('handles download error without message property', () => {
-    __setExecSync((cmd) => {
-        if (cmd.includes('curl')) {
-            const err = new Error();
-            delete err.message; // remove message property
-            throw err;
+        if (savedOutput !== undefined) {
+            process.env.GITHUB_OUTPUT = savedOutput;
         }
-        return Buffer.from('ok');
-    });
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    const code = captureExit(() => withEnv({ INPUT_DOTNET_VERSION: '6.0.x', GITHUB_PATH: ghPath, HOME: tmp }, () => run()));
-    assert.strictEqual(code, 1);
-});
-
-test('skips empty version strings in list', () => {
-    const called = [];
-    __setExecSync((cmd) => {
-        called.push(cmd);
-        return Buffer.from('ok');
-    });
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-    // Mix of valid and empty (after trim) versions
-    withEnv({ INPUT_DOTNET_VERSION: '6.0.x,  , 7.0.100, ', GITHUB_PATH: ghPath, HOME: tmp }, () => run());
-    // Should install 6.0.x and 7.0.100, skipping the empty entries
-    const installCalls = called.filter(c => c.includes('bash') && c.includes('dotnet-install.sh'));
-    assert.strictEqual(installCalls.length, 2);
-});
-
-test('finally block handles rmSync failure gracefully', () => {
-    // Mock fs.rmSync to throw an error
-    const origRmSync = fs.rmSync;
-    let rmSyncCalled = false;
-    fs.rmSync = (p, opts) => {
-        rmSyncCalled = true;
-        throw new Error('rmSync simulated failure');
-    };
-
-    __setExecSync(() => Buffer.from('ok'));
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gh-'));
-    const ghPath = path.join(tmp, 'out');
-    fs.writeFileSync(ghPath, '');
-
-    try {
-        // This should complete without throwing despite rmSync failure
-        withEnv({ INPUT_DOTNET_VERSION: '6.0.x', GITHUB_PATH: ghPath, HOME: tmp }, () => run());
-        assert.ok(rmSyncCalled, 'rmSync should have been called');
-    } finally {
-        fs.rmSync = origRmSync;
     }
 });


### PR DESCRIPTION
This pull request refactors the `.NET SDK` installation GitHub Action to use the official `actions/setup-dotnet` action instead of the custom install script. The changes simplify the logic, improve maintainability, and update the tests to match the new approach.

**Migration to setup-dotnet and workflow refactor:**

* Updated the action description in `action.yml` to reflect the use of `actions/setup-dotnet` instead of the custom install script.
* Replaced the custom SDK installation step with logic that parses up to five requested .NET SDK versions and installs each using `actions/setup-dotnet@v6`. Each version is installed in a separate step, controlled by outputs from the parsing script.

**Simplification and cleanup of install script:**

* Removed all logic related to downloading and running the `dotnet-install.sh` script from `dotnet-install.js`. The script now only parses the input versions and writes them to `GITHUB_OUTPUT` for use by subsequent workflow steps. [[1]](diffhunk://#diff-92d104d72a87d8261050c08d2e192d8c27320e1cdc6695fae0cd1ff90e81bcbfL2-L8) [[2]](diffhunk://#diff-92d104d72a87d8261050c08d2e192d8c27320e1cdc6695fae0cd1ff90e81bcbfL28-R43)

**Test suite updates:**

* Refactored `dotnet-install.test.js` to remove tests related to the old install script logic (e.g., directory creation, installer download, cleanup), and added/updated tests to verify version parsing, output writing, and error handling for the new approach.