### PR TITLE
fix: various bugs and update how nuget release workflow works

### DIFF
--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -131,15 +131,25 @@ runs:
         find-project: true
         find-solution: false
 
+    - name: Get Unique Root Directory
+      id: get-root-directory
+      uses: Now-Micro/actions/get-unique-root-directories@v1
+      with:
+        debug-mode: ${{ inputs['ci-debug-mode'] }}
+        output-is-json: "false"
+        pattern: '^src/([^/]+)/'
+        paths: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}
+
     - name: Get Project File (Test)
       id: extract-project-test
-      if: ${{ inputs['tests-directory'] != '' }}
       uses: Now-Micro/actions/get-project-and-solution-files-from-directory@v1
       with:
-        directory: ${{ inputs['tests-directory'] }}
         debug-mode: ${{ inputs['ci-debug-mode'] }}
+        directory: ${{ inputs['tests-directory'] != '' && inputs['tests-directory'] || format('{0}', fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0]) }}
         find-project: true
         find-solution: false
+        project-regex: format('{0}.Tests.csproj', ${{ steps.get-version.outputs.library_name }})
+        max-depth: 5
 
     - name: Nuget Publish
       uses: Now-Micro/actions/nuget/publish@v1

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -133,7 +133,9 @@ runs:
 
     - name: Get Unique Root Directory
       id: get-root-directory
-      uses: Now-Micro/actions/get-unique-project-directories@v1
+      # TODO: uncomment this before merging, currently using a local path for testing
+      # uses:  Now-Micro/actions/get-unique-project-directories@v1
+      uses: ./get-unique-project-directories
       with:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
         paths: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -140,7 +140,7 @@ runs:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
         paths: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}
         pattern: "^.*/src/.*"
-        transformer: "s#^(.*?)/src/(.*)$#$1/tests/$2#"
+        transformer: "s#^(.*?)/src/(.*)$#$1/tests#"
         throw-if-transformed-not-found: "false"
 
     - name: Get Project File (Test)
@@ -148,7 +148,7 @@ runs:
       uses: Now-Micro/actions/get-project-and-solution-files-from-directory@v1
       with:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
-        directory: ${{ inputs['tests-directory'] != '' && inputs['tests-directory'] || format('{0}', fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0]) }}
+        directory: ${{ inputs['tests-directory'] != '' && inputs['tests-directory'] || format('{0}', fromJSON(steps.get-root-directory.outputs.unique-project-directories || '[]')[0]) }}
         find-project: true
         find-solution: false
         project-regex: format('{0}.Tests.csproj', ${{ steps.get-version.outputs.library_name }})

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -137,7 +137,7 @@ runs:
       with:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
         paths: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}
-        pattern: "^.*/src/.*\\.(cs|csproj|sln|slnx)$"
+        pattern: "^.*/src/.*"
         transformer: "s#^(.*?)/src/(.*)$#$1/tests/$2#"
         throw-if-transformed-not-found: "false"
 

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -165,7 +165,6 @@ runs:
         directory: ${{ inputs['tests-directory'] != '' && inputs['tests-directory'] || format('{0}', fromJSON(steps.get-root-directory.outputs.unique-project-directories || '[]')[0]) }}
         find-project: true
         find-solution: false
-        max-depth: 5
 
     - name: Nuget Publish
       uses: Now-Micro/actions/nuget/publish@v1

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -133,12 +133,13 @@ runs:
 
     - name: Get Unique Root Directory
       id: get-root-directory
-      uses: Now-Micro/actions/get-unique-root-directories@v1
+      uses: Now-Micro/actions/get-unique-project-directories@v1
       with:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
-        output-is-json: "false"
-        pattern: '^([^/]+)/'
         paths: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}
+        pattern: "^.*/src/.*\\.(cs|csproj|sln|slnx)$"
+        transformer: "s#^(.*?)/src/(.*)$#$1/tests/$2#"
+        throw-if-transformed-not-found: "false"
 
     - name: Get Project File (Test)
       id: extract-project-test

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -159,6 +159,7 @@ runs:
 
     - name: Get Project File (Test)
       id: extract-project-test
+      if: ${{ inputs['tests-directory'] != '' || (steps.get-root-directory.outputs.unique_project_directories != '' && steps.get-root-directory.outputs.unique_project_directories != '[]') }}
       uses: Now-Micro/actions/get-project-and-solution-files-from-directory@v1
       with:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
@@ -179,7 +180,7 @@ runs:
         nuget-usernames: ${{ github.actor }}
         project-file: ${{ steps.extract-project-main.outputs.project-found }}
         package-directory: ${{ inputs['package-directory'] != '' && inputs['package-directory'] || 'nupkgs' }}
-        test-project-file: ${{ inputs['tests-directory'] != '' && steps.extract-project-test.outputs.project-found || '' }}
+        test-project-file: ${{ steps.extract-project-test.outputs.project-found || '' }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v6

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -92,7 +92,17 @@ runs:
         ignore-casing: ${{ inputs['ignore-casing'] }}
         debug-mode: ${{ inputs['release-workflow-debug-mode'] }}
 
-    - name: Validate outputs
+    - name: Extract Changelog
+      id: extract-changelog
+      uses: Now-Micro/actions/extract-changelog@v1
+      with:
+        library-directory: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}
+        library-name: ${{ steps.get-version.outputs.library_name }}
+        changelog-content-path: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}/CHANGELOG-EXTRACTED.md
+        create-artifact: "false"
+        version: ${{ steps.get-version.outputs.version }}
+
+    - name: Validate outputs and changelog existence
       shell: bash
       env:
         MATCHED_DIRS_JSON: ${{ steps.path-finder.outputs.matched-dirs-absolute || '[]' }}
@@ -120,6 +130,10 @@ runs:
         if [ "${{ inputs['dry-run'] }}" != "true" ] && [ -z "${{ inputs['github-token'] }}" ]; then  
           echo "Input 'github-token' is required when 'dry-run' is not 'true'.";  
           exit 1;  
+        fi
+        if [ -z "${{ steps.extract-changelog.outputs.changelog-content }}" ]; then
+          echo "No changelog content found for version ${{ steps.get-version.outputs.version }}. Ensure a CHANGELOG.md exists and contains an entry for this version.";
+          exit 1;
         fi
 
     - name: Get Project File (Main)

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -137,7 +137,7 @@ runs:
       with:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
         output-is-json: "false"
-        pattern: '^src/([^/]+)/'
+        pattern: '^([^/]+)/'
         paths: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}
 
     - name: Get Project File (Test)

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -162,7 +162,7 @@ runs:
       uses: Now-Micro/actions/get-project-and-solution-files-from-directory@v1
       with:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
-        directory: ${{ inputs['tests-directory'] != '' && inputs['tests-directory'] || format('{0}', fromJSON(steps.get-root-directory.outputs.unique-project-directories || '[]')[0]) }}
+        directory: ${{ inputs['tests-directory'] != '' && inputs['tests-directory'] || format('{0}', fromJSON(steps.get-root-directory.outputs.unique_project_directories || '[]')[0]) }}
         find-project: true
         find-solution: false
 

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -165,7 +165,6 @@ runs:
         directory: ${{ inputs['tests-directory'] != '' && inputs['tests-directory'] || format('{0}', fromJSON(steps.get-root-directory.outputs.unique-project-directories || '[]')[0]) }}
         find-project: true
         find-solution: false
-        project-regex: ${{ format('{0}.Tests.csproj', steps.get-version.outputs.library_name) }}
         max-depth: 5
 
     - name: Nuget Publish

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -151,7 +151,7 @@ runs:
         directory: ${{ inputs['tests-directory'] != '' && inputs['tests-directory'] || format('{0}', fromJSON(steps.get-root-directory.outputs.unique-project-directories || '[]')[0]) }}
         find-project: true
         find-solution: false
-        project-regex: format('{0}.Tests.csproj', ${{ steps.get-version.outputs.library_name }})
+        project-regex: ${{ format('{0}.Tests.csproj', steps.get-version.outputs.library_name) }}
         max-depth: 5
 
     - name: Nuget Publish

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -147,9 +147,7 @@ runs:
 
     - name: Get Unique Root Directory
       id: get-root-directory
-      # TODO: uncomment this before merging, currently using a local path for testing
-      # uses:  Now-Micro/actions/get-unique-project-directories@v1
-      uses: ./get-unique-project-directories
+      uses:  Now-Micro/actions/get-unique-project-directories@v1
       with:
         debug-mode: ${{ inputs['ci-debug-mode'] }}
         paths: ${{ fromJSON(steps.path-finder.outputs.matched-dirs-absolute || '[]')[0] }}

--- a/.github/actions/run-demo-workflows/action.yml
+++ b/.github/actions/run-demo-workflows/action.yml
@@ -19,6 +19,16 @@ runs:
       with:
         fetch-depth: 0
 
+    - name: Inject demo changelog entry
+      shell: bash
+      run: |
+        VERSION="0.0.0-ci.${{ github.run_id }}.${{ github.run_attempt }}"
+        CHANGELOG="src/demo/dotnet/src/Api/CHANGELOG.md"
+        ENTRY="## [${VERSION}] - $(date -u +%Y-%m-%d)\n\n### Added\n\n- Demo CI release for run ${{ github.run_id }}\n"
+        # Insert after the first line that starts with "## ["
+        awk -v entry="$ENTRY" '/^## \[/{if(!done){printf "%s\n", entry; done=1}} {print}' "$CHANGELOG" > "${CHANGELOG}.tmp"
+        mv "${CHANGELOG}.tmp" "$CHANGELOG"
+
     - name: Demo - nuget publish workflow
       uses: ./.github/actions/nuget-publish-workflow
       with:

--- a/.github/workflows/demo-nuget-publish.yml
+++ b/.github/workflows/demo-nuget-publish.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: "true"
+      cleanup-release:
+        description: "Whether to delete the created GitHub release and tag during cleanup."
+        required: false
+        type: string
+        default: "true"
       ignore-casing:
         description: "Ignore casing when parsing release refs and matching package names."
         required: false
@@ -83,6 +88,7 @@ jobs:
         with:
           artifact-retention-days: ${{ inputs['artifact-retention-days'] }}
           ci-debug-mode: ${{ inputs['ci-debug-mode'] }}
+          cleanup-release: ${{ inputs['cleanup-release'] }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           ignore-casing: ${{ inputs['ignore-casing'] }}
           package-directory: ${{ inputs['package-directory'] != '' && inputs['package-directory'] || 'nupkgs' }}

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,3 +1,4 @@
 # TODOS
 
-- still need to add a check early on for changelogs.md file in the right spot and fail if not found?
+- test how this new reusable action works in CodeBits.  
+- check if the checks.yml stuff still works with the changes related to get-unique-project-directories.js (in CodeBits)

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,4 +1,0 @@
-# TODOS
-
-- test how this new reusable action works in CodeBits.  
-- check if the checks.yml stuff still works with the changes related to get-unique-project-directories.js (in CodeBits)

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,3 @@
+# TODOS
+
+- how do i generate the test directory automatically when no value is given so it doesn't need to be entered? This is important for CodeBit implementation cases where the directory structure is diverse

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,3 +1,4 @@
 # TODOS
 
 - how do i generate the test directory automatically when no value is given so it doesn't need to be entered? This is important for CodeBit implementation cases where the directory structure is diverse
+- still need to add a check early on for changelogs.md file in the right spot and fail if not found?

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,4 +1,3 @@
 # TODOS
 
-- how do i generate the test directory automatically when no value is given so it doesn't need to be entered? This is important for CodeBit implementation cases where the directory structure is diverse
 - still need to add a check early on for changelogs.md file in the right spot and fail if not found?

--- a/get-unique-project-directories/get-unique-project-directories.js
+++ b/get-unique-project-directories/get-unique-project-directories.js
@@ -99,7 +99,13 @@ function findNearestCsproj(inputPath) {
     if (!normalized) return '';
 
     const absoluteFile = path.resolve(normalized);
-    let currentDir = path.dirname(absoluteFile);
+    let currentDir;
+    try {
+        const stat = fs.statSync(absoluteFile);
+        currentDir = stat.isDirectory() ? absoluteFile : path.dirname(absoluteFile);
+    } catch {
+        currentDir = path.dirname(absoluteFile);
+    }
     const rootDir = path.parse(absoluteFile).root;
 
     while (true) {

--- a/get-unique-project-directories/get-unique-project-directories.js
+++ b/get-unique-project-directories/get-unique-project-directories.js
@@ -17,7 +17,9 @@ function normalizePath(input) {
     const stripped = input.trim().replace(/['"\[\]]/g, '');
     const withSlashes = stripped.replace(/\\/g, '/');
     const collapsed = withSlashes.replace(/\/\/+/g, '/');
-    return collapsed.replace(/^\/+/g, '').replace(/\/+$/g, '').trim();
+    const isAbsolute = collapsed.startsWith('/');
+    const trimmed = collapsed.replace(/^\/+/g, '').replace(/\/+$/g, '').trim();
+    return isAbsolute ? '/' + trimmed : trimmed;
 }
 
 function parseTransformer(spec) {

--- a/get-unique-project-directories/get-unique-project-directories.test.js
+++ b/get-unique-project-directories/get-unique-project-directories.test.js
@@ -487,10 +487,13 @@ test('findNearestCsproj tolerates missing directories', () => {
 
 test('findNearestCsproj resolves when input is a directory containing a csproj', () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gu-dir-'));
-    const projectDir = path.join(root, 'src', 'Api');
-    fs.mkdirSync(projectDir, { recursive: true });
-    fs.writeFileSync(path.join(projectDir, 'Api.csproj'), '<Project />');
-    const result = findNearestCsproj(projectDir);
-    assert.ok(result.endsWith('Api.csproj'), `expected csproj path, got '${result}'`);
-    fs.rmSync(root, { recursive: true, force: true });
+    try {
+        const projectDir = path.join(root, 'src', 'Api');
+        fs.mkdirSync(projectDir, { recursive: true });
+        fs.writeFileSync(path.join(projectDir, 'Api.csproj'), '<Project />');
+        const result = findNearestCsproj(projectDir);
+        assert.ok(result.endsWith('Api.csproj'), `expected csproj path, got '${result}'`);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+    }
 });

--- a/get-unique-project-directories/get-unique-project-directories.test.js
+++ b/get-unique-project-directories/get-unique-project-directories.test.js
@@ -484,3 +484,13 @@ test('findNearestCsproj tolerates missing directories', () => {
     const result = findNearestCsproj('no/such/dir/file.cs');
     assert.strictEqual(result, '');
 });
+
+test('findNearestCsproj resolves when input is a directory containing a csproj', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gu-dir-'));
+    const projectDir = path.join(root, 'src', 'Api');
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, 'Api.csproj'), '<Project />');
+    const result = findNearestCsproj(projectDir);
+    assert.ok(result.endsWith('Api.csproj'), `expected csproj path, got '${result}'`);
+    fs.rmSync(root, { recursive: true, force: true });
+});

--- a/get-unique-project-directories/get-unique-project-directories.test.js
+++ b/get-unique-project-directories/get-unique-project-directories.test.js
@@ -463,6 +463,8 @@ test('helpers cover parseBool and normalizePath edge cases', () => {
     assert.strictEqual(parseBool(null, true), true);
     assert.strictEqual(parseBool('maybe', true), true);
     assert.strictEqual(normalizePath('  "C\\\\Temp\\Proj\\File.cs"  '), 'C/Temp/Proj/File.cs');
+    assert.strictEqual(normalizePath('/home/runner/work/repo/src/Api'), '/home/runner/work/repo/src/Api');
+    assert.strictEqual(normalizePath('/home/runner/work/repo/src/Api/'), '/home/runner/work/repo/src/Api');
     assert.strictEqual(toDirectoryOnly(''), '');
     assert.strictEqual(toDirectoryOnly('App.csproj'), '.');
     assert.strictEqual(toDirectoryOnly('README.md'), '.');

--- a/src/demo/dotnet/src/Api/CHANGELOG.md
+++ b/src/demo/dotnet/src/Api/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2025-08-01 (v1 tag)
+
+### Added
+
+- Initial release of the actions

--- a/src/demo/dotnet/src/Api/CHANGELOG.md
+++ b/src/demo/dotnet/src/Api/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-08-01 (v1 tag)
+
+### Added
+
+- Testing 1.1.0
+
+## [1.0.1] - 2025-08-01 (v1 tag)
+
+### Added
+
+- Testing 1.0.1
+
 ## [1.0.0] - 2025-08-01 (v1 tag)
 
 ### Added


### PR DESCRIPTION
This pull request introduces improvements to the NuGet publish workflow, enhances the robustness of the `get-unique-project-directories` utility, and adds new test coverage. The most significant changes are grouped below:

**Workflow and Automation Enhancements:**

* Added a new `cleanup-release` input to the NuGet publish workflow, enabling optional deletion of created GitHub releases and tags during cleanup, and ensured this input is passed to the relevant action. (.github/workflows/demo-nuget-publish.yml) [[1]](diffhunk://#diff-b8891fbe37e662f4783faa62fac7f70035c79e49d6d3b3068237815b2630afc8R16-R20) [[2]](diffhunk://#diff-b8891fbe37e662f4783faa62fac7f70035c79e49d6d3b3068237815b2630afc8R91)
* Improved automation in the NuGet publish workflow action by introducing a step to automatically determine the unique root test directory when not explicitly provided, reducing manual configuration. (`.github/actions/nuget-publish-workflow/action.yml`)

**Utility Improvements and Testing:**

* Updated `normalizePath` in `get-unique-project-directories.js` to better preserve absolute paths, and expanded test coverage for edge cases involving absolute and trailing slashes. [[1]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L20-R22) [[2]](diffhunk://#diff-0af8bb80ac7dec912600617052a3c28d6801b6c3e6a21d3b81ea02127266df53R466-R467)
* Enhanced `findNearestCsproj` to handle directory inputs robustly and tolerate missing directories, with corresponding new tests to verify correct behavior when the input is a directory containing a `.csproj` file. [[1]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L100-R108) [[2]](diffhunk://#diff-0af8bb80ac7dec912600617052a3c28d6801b6c3e6a21d3b81ea02127266df53R487-R496)

**Documentation:**

* Added a `TODOS.md` file to track open questions and improvements, such as automating test directory generation and enforcing changelog presence.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214163918049438