### PR TITLE
fix(reusable-pre-release): issues with token

### DIFF
--- a/.github/actions/demo-nuget-publish/action.yml
+++ b/.github/actions/demo-nuget-publish/action.yml
@@ -63,7 +63,7 @@ runs:
         additional-pack-args: ${{ inputs.additional-pack-args }}
         directory: ${{ inputs.directory }}
         dotnet-version: "8.0.x"
-        github-token: ${{ inputs.github-token }}
+        github-token: ""
         project-regex: 'Api\.csproj$'
 
     - name: Assert remote publish without token failed

--- a/.github/actions/demo-pre-release-workflow/action.yml
+++ b/.github/actions/demo-pre-release-workflow/action.yml
@@ -23,9 +23,6 @@ inputs:
     description: "The .NET version(s) to install, comma-separated (e.g. '8.0.x,10.0.x')."
     required: false
     default: "8.0.x"
-  github-token:
-    description: "GitHub token with permissions to publish packages."
-    required: true
   nuget-urls:
     description: "NuGet feed URL to publish to."
     required: false
@@ -60,7 +57,6 @@ runs:
         ci-debug-mode: ${{ inputs['ci-debug-mode'] }}
         directory: ${{ inputs['directory'] }}
         dotnet-version: ${{ inputs['dotnet-version'] }}
-        github-token: ${{ inputs['github-token'] }}
         nuget-urls: ${{ inputs['nuget-urls'] }}
         prerelease-identifier: ${{ inputs['prerelease-identifier'] }}
         token-github-packages: ${{ inputs['token-github-packages'] }}
@@ -70,7 +66,7 @@ runs:
       if: always() && inputs['delete-published-package'] == 'true' && steps.pre-release.outputs.version-number != ''
       uses: actions/github-script@v8
       with:
-        github-token: ${{ inputs['github-token'] }}
+        github-token: ${{ inputs['token-github-packages'] }}
         script: |
           const packageName = '${{ steps.pre-release.outputs.package-name }}';
           const versionNumber = '${{ steps.pre-release.outputs.version-number }}';

--- a/.github/actions/demo-pre-release-workflow/action.yml
+++ b/.github/actions/demo-pre-release-workflow/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: "8.0.x"
   github-token:
-    description: "GitHub token with permissions to delete packages."
+    description: "GitHub token with permissions to publish packages."
     required: true
   nuget-urls:
     description: "NuGet feed URL to publish to."

--- a/.github/actions/demo-pre-release-workflow/action.yml
+++ b/.github/actions/demo-pre-release-workflow/action.yml
@@ -62,6 +62,15 @@ runs:
         token-github-packages: ${{ inputs['token-github-packages'] }}
         version-increment-type: ${{ inputs['version-increment-type'] }}
 
+    - name: Debug - pre-release delete condition values
+      if: always()
+      shell: bash
+      run: |
+        echo "delete-published-package = '${{ inputs['delete-published-package'] }}'"
+        echo "steps.pre-release.outputs.version-number = '${{ steps.pre-release.outputs.version-number }}'"
+        echo "steps.pre-release.outputs.package-name = '${{ steps.pre-release.outputs.package-name }}'"
+        echo "steps.pre-release outcome = '${{ steps.pre-release.outcome }}'"
+
     - name: Delete published pre-release package version
       if: always() && inputs['delete-published-package'] == 'true' && steps.pre-release.outputs.version-number != ''
       uses: actions/github-script@v8

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -234,3 +234,46 @@ runs:
               throw error;
             }
           }
+
+    - name: Delete published NuGet package version
+      if: ${{ always() && inputs['cleanup-release'] == 'true' && inputs['dry-run'] != 'true' && steps.publish-release.outputs.release-url != '' }}
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ inputs['token-github-packages'] }}
+        script: |
+          const packageName = '${{ steps.get-version.outputs.library_name }}';
+          const versionNumber = '${{ steps.get-version.outputs.version }}';
+          const org = context.repo.owner;
+
+          core.info(`🔍 Looking for package '${packageName}' version '${versionNumber}' in org '${org}'`);
+
+          let versions;
+          try {
+            const resp = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
+              org,
+              package_type: 'nuget',
+              package_name: packageName,
+            });
+            versions = resp.data;
+          } catch (err) {
+            core.warning(`Could not list package versions: ${err.message}`);
+            return;
+          }
+
+          const match = versions.find(v => v.name === versionNumber);
+          if (!match) {
+            core.info(`ℹ️ Version '${versionNumber}' not found in package '${packageName}' — nothing to delete.`);
+            return;
+          }
+
+          try {
+            await github.rest.packages.deletePackageVersionForOrg({
+              org,
+              package_type: 'nuget',
+              package_name: packageName,
+              package_version_id: match.id,
+            });
+            core.info(`✅ Deleted NuGet package version: ${packageName}@${versionNumber}`);
+          } catch (err) {
+            core.warning(`Failed to delete package version: ${err.message}`);
+          }

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: "true"
   nuget-urls:
-    description: "Nuget feed URLs to publish to, separated by commas. Required if token-github-packages is provided."
+    description: "Nuget feed URLs needed to build the projects. Should be a comma-separated list of URLs."
     required: false
     default: ""
   package:

--- a/.github/actions/reusable-pre-release-workflow/action.yml
+++ b/.github/actions/reusable-pre-release-workflow/action.yml
@@ -57,10 +57,10 @@ inputs:
 outputs:
   version-number:
     description: "The full pre-release version number that was published (e.g. 1.2.3-alpha-202505051430)."
-    value: ${{ steps.calc-version.outputs.version_number }}
+    value: ${{ steps.calc-version.outputs.version-number }}
   package-name:
     description: "The NuGet package name that was published."
-    value: ${{ steps.extract-project.outputs.project_name }}
+    value: ${{ steps.extract-project.outputs.project-name }}
 
 runs:
   using: "composite"
@@ -132,7 +132,7 @@ runs:
     - name: Upload pre-release artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ steps.extract-project.outputs.project_name }}-${{
+        name: ${{ steps.extract-project.outputs.project-name }}-${{
           steps.calc-version.outputs.version-number }}-${{
           steps.slug.outputs.dir_slug }}
         path: |

--- a/.github/actions/reusable-pre-release-workflow/action.yml
+++ b/.github/actions/reusable-pre-release-workflow/action.yml
@@ -22,9 +22,6 @@ inputs:
       Should be a comma-separated list of versions (e.g. '8.0.x,10.0.x')."
     required: false
     default: "8.0.x"
-  github-token:
-    description: "GitHub token with permissions to create packages and upload artifacts."
-    required: true
   nuget-package-dir:
     description: "Directory to store generated package artifacts."
     required: false
@@ -42,7 +39,7 @@ inputs:
     required: false
     default: ".*\\.csproj$"
   nuget-urls:
-    description: "Nuget feed URLs to publish to, separated by commas."
+    description: "Nuget feed URLs needed to build the projects.  Should be a comma-separated list of URLs."
     required: false
     default: ""
   prerelease-identifier:
@@ -124,7 +121,7 @@ runs:
           steps.calc-version.outputs.version-number }} -p:IncludeSymbols=true
           -p:SymbolPackageFormat=snupkg
         dotnet-version: ${{ inputs.dotnet-version }}
-        github-token: ${{ inputs.github-token }}
+        github-token: ${{ inputs.token-github-packages }}
         nuget-names: "github"
         nuget-passwords: ${{ inputs.token-github-packages }}
         nuget-urls: ${{ inputs.nuget-urls }}

--- a/.github/actions/reusable-pre-release-workflow/action.yml
+++ b/.github/actions/reusable-pre-release-workflow/action.yml
@@ -60,7 +60,7 @@ outputs:
     value: ${{ steps.calc-version.outputs.version-number }}
   package-name:
     description: "The NuGet package name that was published."
-    value: ${{ steps.extract-project.outputs.project-name }}
+    value: ${{ steps.pkg-name.outputs.package-name }}
 
 runs:
   using: "composite"
@@ -102,6 +102,14 @@ runs:
         find-solution: false
         project-regex: ${{ inputs.nuget-project-regex }}
 
+    - name: Derive package name
+      id: pkg-name
+      shell: bash
+      run: |
+        name="${{ steps.extract-project.outputs.project-name }}"
+        name="${name%.csproj}"
+        echo "package-name=$name" >> "$GITHUB_OUTPUT"
+
     - name: Calculate pre-release version
       id: calc-version
       uses: Now-Micro/actions/generate-version@v1
@@ -132,7 +140,7 @@ runs:
     - name: Upload pre-release artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: ${{ steps.extract-project.outputs.project-name }}-${{
+        name: ${{ steps.pkg-name.outputs.package-name }}-${{
           steps.calc-version.outputs.version-number }}-${{
           steps.slug.outputs.dir_slug }}
         path: |

--- a/.github/actions/run-demo-workflows/action.yml
+++ b/.github/actions/run-demo-workflows/action.yml
@@ -22,7 +22,8 @@ runs:
     - name: Demo - pre-release-workflow
       uses: ./.github/actions/demo-pre-release-workflow
       with:
-        github-token: ${{ inputs.github-token }}
+        delete-published-package: "true"
+        directory: "src/demo/dotnet/src/Api"
         token-github-packages: ${{ inputs.github-token }}
 
     - name: Inject demo changelog entry

--- a/.github/workflows/demo-pre-release.yml
+++ b/.github/workflows/demo-pre-release.yml
@@ -79,7 +79,6 @@ jobs:
                   ci-debug-mode: ${{ inputs['ci-debug-mode'] }}
                   delete-published-package: ${{ inputs['delete-published-package'] }}
                   directory: ${{ inputs['directory'] }}
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   dotnet-version: ${{ inputs['dotnet-version'] }}
                   nuget-urls: ${{ inputs['nuget-urls'] }}
                   prerelease-identifier: ${{ inputs['prerelease-identifier'] }}

--- a/.github/workflows/demo-pre-release.yml
+++ b/.github/workflows/demo-pre-release.yml
@@ -34,10 +34,10 @@ on:
                 type: string
                 default: "8.0.x"
             nuget-urls:
-                description: "NuGet feed URLs to publish to, separated by commas."
+                description: "NuGet feed URLs needed to build the projects. Should be a comma-separated list of URLs."
                 required: false
                 type: string
-                default: "https://nuget.pkg.github.com/actions/index.json"
+                default: ""
             prerelease-identifier:
                 description: "Pre-release identifier."
                 required: false

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -22,7 +22,7 @@ on:
                 required: false
                 type: string
             nuget-urls:
-                description: "Nuget feed URLs to publish to, separated by commas."
+                description: "Nuget feed URLs needed to build the projects. Should be a comma-separated list of URLs."
                 required: false
                 type: string
             package:

--- a/.github/workflows/reusable-pre-release.yml
+++ b/.github/workflows/reusable-pre-release.yml
@@ -72,10 +72,6 @@ on:
                 type: string
                 default: "none"
         secrets:
-            github-token:
-                description: "GitHub token with permissions to read from the repository and
-                    publish packages."
-                required: true
             token-github-packages:
                 description: "PAT used to authenticate to GitHub Packages."
                 required: true
@@ -88,7 +84,6 @@ jobs:
               shell: bash
               env:
                   NUGET_URLS: ${{ inputs['nuget-urls'] }}
-                  GITHUB_TOKEN_INPUT: ${{ secrets['github-token'] }}
                   TOKEN_GITHUB_PACKAGES: ${{ secrets['token-github-packages'] }}
               run: |
                   valid_identifiers="alpha beta preview rc"
@@ -99,11 +94,6 @@ jobs:
 
                   if [[ -z "$NUGET_URLS" ]]; then
                     echo "❌ Required input 'nuget-urls' is empty."
-                    exit 1
-                  fi
-
-                  if [[ -z "$GITHUB_TOKEN_INPUT" ]]; then
-                    echo "❌ Required secret 'github-token' is empty."
                     exit 1
                   fi
 
@@ -164,7 +154,6 @@ jobs:
                   ci-debug-mode: ${{ inputs['ci-debug-mode'] }}
                   dotnet-version: ${{ inputs['dotnet-version'] }}
                   directory: ${{ inputs['directory'] }}
-                  github-token: ${{ secrets['github-token'] }}
                   nuget-package-dir: ${{ inputs['nuget-package-dir'] }}
                   nuget-pattern-to-match: ${{ inputs['nuget-pattern-to-match'] }}
                   nuget-project-regex: ${{ inputs['nuget-project-regex'] }}
@@ -198,7 +187,6 @@ jobs:
                   ci-debug-mode: ${{ inputs['ci-debug-mode'] }}
                   directory: ${{ matrix.directory }}
                   dotnet-version: ${{ inputs['dotnet-version'] }}
-                  github-token: ${{ secrets['github-token'] }}
                   nuget-package-dir: ${{ inputs['nuget-package-dir'] }}
                   nuget-pattern-to-match: ${{ inputs['nuget-pattern-to-match'] }}
                   nuget-project-regex: ${{ inputs['nuget-project-regex'] }}

--- a/src/demo/coding-standards-fail/src/Demo.Linting/Demo.Linting.csproj
+++ b/src/demo/coding-standards-fail/src/Demo.Linting/Demo.Linting.csproj
@@ -7,6 +7,8 @@
     <!-- <AnalysisLevel>latest-all</AnalysisLevel> -->
     <!-- <EnableNETAnalyzers>true</EnableNETAnalyzers> -->
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <!-- Uncomment below when trying to build locally (dotnet build .\src\demo\coding-standards-fail\).  You have to run 2 times to get the full list of errors due to where the .editorconfig is located -->
   <!-- <Target Name="UseSharedEditorConfig" BeforeTargets="CoreCompile">

--- a/src/demo/coding-standards-success/src/Demo.Linting/Demo.Linting.csproj
+++ b/src/demo/coding-standards-success/src/Demo.Linting/Demo.Linting.csproj
@@ -7,6 +7,8 @@
     <!-- <AnalysisLevel>latest-all</AnalysisLevel> -->
     <!-- <EnableNETAnalyzers>true</EnableNETAnalyzers> -->
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <!-- Uncomment below when trying to build locally (dotnet build .\src\demo\coding-standards-success\).  You have to run 2 times to get the full list of errors due to where the .editorconfig is located -->
   <!-- <Target Name="UseSharedEditorConfig" BeforeTargets="CoreCompile">

--- a/src/demo/dotnet/src/Api/Api.csproj
+++ b/src/demo/dotnet/src/Api/Api.csproj
@@ -18,6 +18,7 @@
     <Copyright>Copyright © Trafera</Copyright>
     <PackageTags>csi;erp;api;client;trafera</PackageTags>
     <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsNotAsErrors>CS1591</WarningsNotAsErrors>

--- a/src/demo/dotnet/tests/Api.Tests/Api.Tests.csproj
+++ b/src/demo/dotnet/tests/Api.Tests/Api.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Demo.Api.Tests</RootNamespace>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/src/demo/get-project-and-solution-files-from-directory/SolutionA/src/A/Deeply/Nested/Project/File/ThisShouldNotBeFound.csproj
+++ b/src/demo/get-project-and-solution-files-from-directory/SolutionA/src/A/Deeply/Nested/Project/File/ThisShouldNotBeFound.csproj
@@ -4,5 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Demo.Test</RootNamespace>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
 </Project>

--- a/src/demo/get-project-and-solution-files-from-directory/SolutionA/src/AppA/AppA.csproj
+++ b/src/demo/get-project-and-solution-files-from-directory/SolutionA/src/AppA/AppA.csproj
@@ -2,5 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
 </Project>

--- a/src/demo/get-project-and-solution-files-from-directory/SolutionA/src/AppB/AppB.csproj
+++ b/src/demo/get-project-and-solution-files-from-directory/SolutionA/src/AppB/AppB.csproj
@@ -2,5 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
 </Project>

--- a/src/demo/get-project-and-solution-files-from-directory/SolutionA/tests/Test.csproj
+++ b/src/demo/get-project-and-solution-files-from-directory/SolutionA/tests/Test.csproj
@@ -2,5 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
 </Project>

--- a/src/demo/get-project-and-solution-files-from-directory/SolutionB/src/Service/Service.csproj
+++ b/src/demo/get-project-and-solution-files-from-directory/SolutionB/src/Service/Service.csproj
@@ -2,5 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
 </Project>

--- a/src/demo/get-project-and-solution-files-from-directory/SolutionB/tests/Service.Tests/Service.Tests.csproj
+++ b/src/demo/get-project-and-solution-files-from-directory/SolutionB/tests/Service.Tests/Service.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Service\Service.csproj" />

--- a/src/demo/get-unique-project-directories/samples/Trafera.Messaging.MassTransit.SampleApp/Trafera.Messaging.MassTransit.SampleApp.csproj
+++ b/src/demo/get-unique-project-directories/samples/Trafera.Messaging.MassTransit.SampleApp/Trafera.Messaging.MassTransit.SampleApp.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="8.3.1" />

--- a/src/demo/get-unique-project-directories/samples/Trafera.Messaging.MediatR.SampleApp/Trafera.Messaging.MediatR.SampleApp.csproj
+++ b/src/demo/get-unique-project-directories/samples/Trafera.Messaging.MediatR.SampleApp/Trafera.Messaging.MediatR.SampleApp.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.4.1" />

--- a/src/demo/get-unique-project-directories/src/Trafera.Messaging.Abstractions/Trafera.Messaging.Abstractions.csproj
+++ b/src/demo/get-unique-project-directories/src/Trafera.Messaging.Abstractions/Trafera.Messaging.Abstractions.csproj
@@ -12,6 +12,8 @@
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Trafera messaging abstractions and base exceptions.</Description>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />

--- a/src/demo/get-unique-project-directories/src/Trafera.Messaging.MassTransit/Trafera.Messaging.MassTransit.csproj
+++ b/src/demo/get-unique-project-directories/src/Trafera.Messaging.MassTransit/Trafera.Messaging.MassTransit.csproj
@@ -12,6 +12,8 @@
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Trafera MassTransit integration with RabbitMQ and MongoDB outbox support.</Description>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="8.3.1" />

--- a/src/demo/get-unique-project-directories/src/Trafera.Messaging.MediatR/Trafera.Messaging.MediatR.csproj
+++ b/src/demo/get-unique-project-directories/src/Trafera.Messaging.MediatR/Trafera.Messaging.MediatR.csproj
@@ -12,6 +12,8 @@
     <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Trafera MediatR messaging behaviors and transaction pipeline.</Description>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.11.0" />

--- a/src/demo/get-unique-project-directories/tests/Trafera.Messaging.Abstractions.Tests/Trafera.Messaging.Abstractions.Tests.csproj
+++ b/src/demo/get-unique-project-directories/tests/Trafera.Messaging.Abstractions.Tests/Trafera.Messaging.Abstractions.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/src/demo/get-unique-project-directories/tests/Trafera.Messaging.MassTransit.Tests/Trafera.Messaging.MassTransit.Tests.csproj
+++ b/src/demo/get-unique-project-directories/tests/Trafera.Messaging.MassTransit.Tests/Trafera.Messaging.MassTransit.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/src/demo/get-unique-project-directories/tests/Trafera.Messaging.MediatR.Tests/Trafera.Messaging.MediatR.Tests.csproj
+++ b/src/demo/get-unique-project-directories/tests/Trafera.Messaging.MediatR.Tests/Trafera.Messaging.MediatR.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Now-Micro/actions</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />


### PR DESCRIPTION
This pull request updates the authentication method for publishing pre-release packages by removing the use of the generic `github-token` secret in favor of a more specific `token-github-packages` secret throughout the reusable pre-release workflow. This change streamlines secret management and clarifies which token is required for publishing to GitHub Packages. Additionally, there are minor improvements to input descriptions for clarity.

**Authentication and Secret Management:**

* Removed the `github-token` input and secret from both the reusable workflow (`.github/workflows/reusable-pre-release.yml`) and the associated action (`.github/actions/reusable-pre-release-workflow/action.yml`), consolidating authentication to use only the `token-github-packages` secret. [[1]](diffhunk://#diff-0804f83ecbdbf810ad4123c03c3b99a123e7251a9e24fcafee20c34b2c7bdb23L25-L27) [[2]](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bL75-L78) [[3]](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bL167) [[4]](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bL201)
* Updated the action to use `token-github-packages` instead of `github-token` when publishing packages.
* Removed validation and environment variable usage related to `github-token` in the workflow, ensuring only `token-github-packages` is required and checked. [[1]](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bL91) [[2]](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bL105-L109)

**Documentation and Input Improvements:**

* Clarified the description for the `nuget-urls` input to indicate it's for build-time feed URLs, not just publishing.