### PR TITLE
chore(reusable-pre-release.yml): add needs for detect-changed-libraries

### DIFF
--- a/.github/workflows/reusable-pre-release.yml
+++ b/.github/workflows/reusable-pre-release.yml
@@ -113,6 +113,7 @@ jobs:
                   fi
     
     detect-changed-libraries:
+        needs: [ validate-inputs ]
         if: ${{ inputs.directory == '' }}
         runs-on: ubuntu-22.04
         outputs:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow by adding a dependency to the `detect-changed-libraries` job. The job now explicitly requires the `validate-inputs` job to complete before it runs.