### PR TITLE
chore: update readme and default input values

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -175,7 +175,7 @@ Detects which project directories have changed and publishes a timestamped pre-r
 When `directory` is **not** provided:
 
 1. Gets the list of changed files between the current commit and the base ref.
-2. Extracts unique `src/` project directories from that file list.
+2. Extracts unique `src/` project directories from that file list based on the `nuget-pattern-to-match` input.
 3. Fans out into a matrix job — one publish job per changed directory.
 
 When `directory` **is** provided:
@@ -184,7 +184,7 @@ When `directory` **is** provided:
 
 In both cases, for each directory:
 
-1. Finds the `.csproj` file.
+1. Finds the `.csproj` file based on the `nuget-project-regex` input value.
 2. Calculates a pre-release version (e.g. `1.2.4-alpha-202506011200`) by incrementing the current version and appending an identifier and UTC timestamp.
 3. Builds, packs, and pushes the package to the NuGet feed.
 4. Uploads the artifacts and generates a pre-release summary.

--- a/.github/workflows/reusable-pre-release.yml
+++ b/.github/workflows/reusable-pre-release.yml
@@ -45,10 +45,10 @@ on:
                 description: "Glob pattern to match for determining which changed files should
                     trigger a package publish. Should include a capture group
                     for the project directory (e.g.
-                    '^(.*/src)/.*\\.(cs|csproj|sln)$')."
+                    '^(.*\/src)\/.*\\.(cs|csproj|sln)$')."
                 required: false
                 type: string
-                default: "^(.*/src)/.*\\.(cs|csproj|sln)$"
+                default: "^(.*\/src)\/.*\\.(cs|csproj|sln)$"
             nuget-project-regex:
                 description: "Regex pattern to extract project name from the .csproj file path.
                     Should include a capture group for the project name (e.g.


### PR DESCRIPTION
This pull request updates documentation and workflow configuration to clarify and improve how project directories and project files are detected for NuGet package publishing. The changes make the process more explicit and configurable via regex inputs.

**Documentation improvements:**

* [`.github/workflows/README.md`](diffhunk://#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffbL178-R178): Updated the description to clarify that unique `src/` project directories are now extracted based on the `nuget-pattern-to-match` input, making the matching pattern configurable.
* [`.github/workflows/README.md`](diffhunk://#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffbL187-R187): Clarified that the `.csproj` file is found based on the `nuget-project-regex` input, rather than a fixed approach.

**Workflow configuration:**

* [`.github/workflows/reusable-pre-release.yml`](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bL48-R51): Updated the default and example value for the `nuget-pattern-to-match` input to use a more explicit and consistent regex pattern for matching changed files and extracting project directories.