### PR TITLE
fix(reusable-checks.yml): logic around enable inputs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,10 +50,9 @@ jobs:
           echo "Changed files: ${{ steps.changed-files.outputs.changed_files }}"
           SHOULD_RUN=false
 
-          # Example logic: run tests if any action.yml, .js or .cs files changed
-          # Also run tests if any action.yml files or action folders changed (these affect actions behavior)
           CHANGED_FILES="${{ steps.changed-files.outputs.changed_files }}"
-          if echo "$CHANGED_FILES" | grep -qE '\.js|\.cs|action\.yml|\.github/actions/|\.github/workflows/(demo-nuget-publish|demo-all|release)\.yml|\.github/workflows/reusable[^/]*\.ya?ml'; then
+          if echo "$CHANGED_FILES" | jq -r '.[]' | grep -qE \
+            '\.js$|\.cs$|action\.yml$|^\.github/actions/|^\.github/workflows/(demo-nuget-publish|demo-all|release)\.yml$|^\.github/workflows/reusable[^/]*\.ya?ml$'; then
             SHOULD_RUN=true
           fi
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,7 +40,8 @@ jobs:
         id: changed-files
         with:
           head-ref: ${{ github.event.pull_request.head.sha }}
-          base-ref: ${{ steps.last-success.outputs.last_success_sha || github.event.repository.default_branch }}
+          base-ref: ${{ steps.last-success.outputs.last_success_sha ||
+            github.event.repository.default_branch }}
 
       - name: Check if tests should run based on changed files
         id: check-changed-files
@@ -52,7 +53,7 @@ jobs:
           # Example logic: run tests if any action.yml, .js or .cs files changed
           # Also run tests if any action.yml files or action folders changed (these affect actions behavior)
           CHANGED_FILES="${{ steps.changed-files.outputs.changed_files }}"
-          if echo "$CHANGED_FILES" | grep -qE '\.js|\.cs|action\.yml|\.github/actions/|\.github/workflows/(demo-nuget-publish|demo-all|release)\.yml'; then
+          if echo "$CHANGED_FILES" | grep -qE '\.js|\.cs|action\.yml|\.github/actions/|\.github/workflows/(demo-nuget-publish|demo-all|release)\.yml|\.github/workflows/reusable[^/]*\.ya?ml'; then
             SHOULD_RUN=true
           fi
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,11 +46,12 @@ jobs:
       - name: Check if tests should run based on changed files
         id: check-changed-files
         shell: bash
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
         run: |
-          echo "Changed files: ${{ steps.changed-files.outputs.changed_files }}"
+          echo "Changed files: $CHANGED_FILES"
           SHOULD_RUN=false
 
-          CHANGED_FILES="${{ steps.changed-files.outputs.changed_files }}"
           if echo "$CHANGED_FILES" | jq -r '.[]' | grep -qE \
             '\.js$|\.cs$|action\.yml$|^\.github/actions/|^\.github/workflows/(demo-nuget-publish|demo-all|release)\.yml$|^\.github/workflows/reusable[^/]*\.ya?ml$'; then
             SHOULD_RUN=true

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -123,8 +123,8 @@ on:
                 type: string
                 default: ""
             overridden-changed-files:
-                description: "JSON array of file paths to treat as changed. When set, skips
-                    git change detection entirely and uses these paths for pattern
+                description: "JSON array of file paths to treat as changed. When set, skips git
+                    change detection entirely and uses these paths for pattern
                     matching. Intended for testing and demo scenarios."
                 required: false
                 type: string
@@ -150,7 +150,8 @@ jobs:
 
     validate:
         runs-on: ubuntu-22.04
-        if: ${{ inputs['enable-coding-standards'] == 'true' || inputs['enable-testing'] == 'true' }}
+        if: ${{ inputs['enable-coding-standards'] == 'true' || inputs['enable-testing']
+            == 'true' }}
         steps:
             - name: Validate token-github-packages secret
               shell: bash
@@ -184,13 +185,15 @@ jobs:
                   echo "mode=changes" >> "$GITHUB_OUTPUT"
 
             - name: Check out code
-              if: ${{ steps.mode.outputs.mode == 'changes' && inputs['overridden-changed-files'] == '' }}
+              if: ${{ steps.mode.outputs.mode == 'changes' &&
+                  inputs['overridden-changed-files'] == '' }}
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
             - name: Get Changed Files
-              if: ${{ steps.mode.outputs.mode == 'changes' && inputs['overridden-changed-files'] == '' }}
+              if: ${{ steps.mode.outputs.mode == 'changes' &&
+                  inputs['overridden-changed-files'] == '' }}
               id: changed-files
               uses: Now-Micro/actions/get-changed-files@v1
               with:
@@ -202,7 +205,8 @@ jobs:
               id: unique-dirs
               uses: Now-Micro/actions/get-unique-root-directories@v1
               with:
-                  paths: ${{ inputs['overridden-changed-files'] || steps.changed-files.outputs.changed_files }}
+                  paths: ${{ inputs['overridden-changed-files'] ||
+                      steps.changed-files.outputs.changed_files }}
                   pattern: ${{ inputs['coding-standards-path-pattern'] }}
                   debug-mode: ${{ inputs['ci-debug-mode'] }}
 
@@ -229,7 +233,7 @@ jobs:
 
     code-standards:
         runs-on: ubuntu-22.04
-        needs: [coding-standards-setup, validate]
+        needs: [ coding-standards-setup, validate ]
         if: ${{ inputs['enable-coding-standards'] == 'true' &&
             needs.coding-standards-setup.outputs.directories_to_check != '[]' }}
         strategy:
@@ -276,7 +280,8 @@ jobs:
                   echo "mode=changes" >> "$GITHUB_OUTPUT"
 
             - name: Check out code
-              if: ${{ steps.mode.outputs.mode == 'changes' && inputs['overridden-changed-files'] == '' }}
+              if: ${{ steps.mode.outputs.mode == 'changes' &&
+                  inputs['overridden-changed-files'] == '' }}
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
@@ -297,7 +302,8 @@ jobs:
                   workflow-name: ${{ inputs['workflow-name'] }}
 
             - name: Get Changed Files
-              if: ${{ steps.mode.outputs.mode == 'changes' && inputs['overridden-changed-files'] == '' }}
+              if: ${{ steps.mode.outputs.mode == 'changes' &&
+                  inputs['overridden-changed-files'] == '' }}
               id: changed-files
               uses: Now-Micro/actions/get-changed-files@v1
               with:
@@ -310,7 +316,8 @@ jobs:
               id: unique-dirs
               uses: Now-Micro/actions/get-unique-project-directories@v1
               with:
-                  paths: ${{ inputs['overridden-changed-files'] || steps.changed-files.outputs.changed_files }}
+                  paths: ${{ inputs['overridden-changed-files'] ||
+                      steps.changed-files.outputs.changed_files }}
                   pattern: ${{ inputs['testing-path-pattern'] }}
                   debug-mode: ${{ inputs['ci-debug-mode'] }}
                   fallback-regex: ${{ inputs['testing-path-pattern'] }}
@@ -340,7 +347,7 @@ jobs:
 
     test:
         runs-on: ubuntu-22.04
-        needs: [test-setup, validate]
+        needs: [ test-setup, validate ]
         if: ${{ inputs['enable-testing'] == 'true' &&
             needs.test-setup.outputs.directories_to_test != '[]' }}
         strategy:

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -165,6 +165,7 @@ jobs:
 
     coding-standards-setup:
         runs-on: ubuntu-22.04
+        if: ${{ inputs['enable-coding-standards'] == 'true' }}
         outputs:
             directories_to_check: ${{ steps.resolve-directories.outputs.directories_to_check }}
         steps:
@@ -175,11 +176,6 @@ jobs:
                   ENABLE_CODING_STANDARDS: ${{ inputs['enable-coding-standards'] }}
                   DIRECTORY: ${{ inputs.directory }}
               run: |
-                  if [ "$ENABLE_CODING_STANDARDS" != 'true' ]; then
-                    echo "mode=disabled" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
-
                   if [ -n "$DIRECTORY" ]; then
                     echo "mode=directory" >> "$GITHUB_OUTPUT"
                     echo "directory=$DIRECTORY" >> "$GITHUB_OUTPUT"
@@ -221,9 +217,6 @@ jobs:
                       }}
               run: |
                   case "$MODE" in
-                    disabled)
-                      echo "directories_to_check=[]" >> "$GITHUB_OUTPUT"
-                      ;;
                     directory)
                       echo "directories_to_check=$(jq -nc --arg dir "$DIRECTORY" '[ $dir ]')" >> "$GITHUB_OUTPUT"
                       ;;
@@ -265,6 +258,7 @@ jobs:
 
     test-setup:
         runs-on: ubuntu-22.04
+        if: ${{ inputs['enable-testing'] == 'true' }}
         outputs:
             directories_to_test: ${{ steps.resolve-directories.outputs.directories_to_test }}
         steps:
@@ -275,11 +269,6 @@ jobs:
                   ENABLE_TESTING: ${{ inputs['enable-testing'] }}
                   DIRECTORY: ${{ inputs.directory }}
               run: |
-                  if [ "$ENABLE_TESTING" != 'true' ]; then
-                    echo "mode=disabled" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  fi
-
                   if [ -n "$DIRECTORY" ]; then
                     echo "mode=directory" >> "$GITHUB_OUTPUT"
                     echo "directory=$DIRECTORY" >> "$GITHUB_OUTPUT"
@@ -340,9 +329,6 @@ jobs:
                       '[]' }}
               run: |
                   case "$MODE" in
-                    disabled)
-                      echo "directories_to_test=[]" >> "$GITHUB_OUTPUT"
-                      ;;
                     directory)
                       echo "directories_to_test=$(jq -nc --arg dir "$DIRECTORY" '[ $dir ]')" >> "$GITHUB_OUTPUT"
                       ;;

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -173,7 +173,6 @@ jobs:
               id: mode
               shell: bash
               env:
-                  ENABLE_CODING_STANDARDS: ${{ inputs['enable-coding-standards'] }}
                   DIRECTORY: ${{ inputs.directory }}
               run: |
                   if [ -n "$DIRECTORY" ]; then
@@ -266,7 +265,6 @@ jobs:
               id: mode
               shell: bash
               env:
-                  ENABLE_TESTING: ${{ inputs['enable-testing'] }}
                   DIRECTORY: ${{ inputs.directory }}
               run: |
                   if [ -n "$DIRECTORY" ]; then


### PR DESCRIPTION
This pull request introduces improvements to the GitHub Actions workflow configuration, mainly focusing on making job execution more conditional and refining how changed files trigger tests. The changes enhance efficiency by ensuring jobs only run when relevant, and streamline the logic for determining which directories to check or test.

**Workflow trigger improvements:**

* Updated the file change detection logic in `.github/workflows/checks.yml` to also trigger tests when any reusable workflow files (`.github/workflows/reusable*.yml` or `.yaml`) are changed, in addition to the existing patterns.

**Conditional job execution:**

* Added conditional checks (`if:` statements) to the `coding-standards-setup` and `test-setup` jobs in `.github/workflows/reusable-checks.yml` so that these jobs only run when the corresponding input (`enable-coding-standards` or `enable-testing`) is set to `'true'`. [[1]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6R168) [[2]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6R261)

**Simplification of directory resolution logic:**

* Removed explicit handling and output for the `'disabled'` mode in both the coding standards and testing setup jobs, relying instead on the new conditional job execution to skip these steps when not needed. [[1]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L178-L182) [[2]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L224-L226) [[3]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L278-L282) [[4]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L343-L345)