### PR TITLE
fix(reusable-checks.yml): checkout code issue

### DIFF
--- a/.github/workflows/demo-checks.yml
+++ b/.github/workflows/demo-checks.yml
@@ -63,13 +63,16 @@ jobs:
     # ── Tests – change detection (via reusable workflow) ───────────────────
     # Same approach: inject a known demo file path so the change-detection path
     # detects src/demo/dotnet and runs tests there.
+    # We inject the test project file directly so get-unique-project-directories
+    # resolves to src/demo/dotnet/tests/Api.Tests (the transformer won't match
+    # a tests/ path to a valid directory, so use-original-if-missing kicks in).
     test-change-detection:
         uses: ./.github/workflows/reusable-checks.yml
         with:
             enable-testing: "true"
             testing-path-pattern: "^(src/demo/dotnet)/.*\\.(cs|csproj|sln|slnx)$"
             use-original-if-missing: "true"
-            overridden-changed-files: '["src/demo/dotnet/src/Api/Api.csproj"]'
+            overridden-changed-files: '["src/demo/dotnet/tests/Api.Tests/Api.Tests.csproj"]'
             dotnet-version: "8.0.x"
             test-project-regex: '.*Tests\.csproj\s*$'
             ci-debug-mode: "true"

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -171,7 +171,6 @@ jobs:
             directories_to_check: ${{ steps.resolve-directories.outputs.directories_to_check }}
         steps:
             - name: Check out code
-              if: ${{ inputs['overridden-changed-files'] == '' }}
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
@@ -266,7 +265,6 @@ jobs:
             directories_to_test: ${{ steps.resolve-directories.outputs.directories_to_test }}
         steps:
             - name: Check out code
-              if: ${{ inputs['overridden-changed-files'] == '' }}
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -170,12 +170,19 @@ jobs:
         outputs:
             directories_to_check: ${{ steps.resolve-directories.outputs.directories_to_check }}
         steps:
+            - name: Check out code
+              if: ${{ inputs['overridden-changed-files'] == '' }}
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
             - name: Determine coding standards mode
               id: mode
               shell: bash
               env:
                   DIRECTORY: ${{ inputs.directory }}
               run: |
+                  echo "Input directory: $DIRECTORY"
                   if [ -n "$DIRECTORY" ]; then
                     echo "mode=directory" >> "$GITHUB_OUTPUT"
                     echo "directory=$DIRECTORY" >> "$GITHUB_OUTPUT"
@@ -183,13 +190,6 @@ jobs:
                   fi
 
                   echo "mode=changes" >> "$GITHUB_OUTPUT"
-
-            - name: Check out code
-              if: ${{ steps.mode.outputs.mode == 'changes' &&
-                  inputs['overridden-changed-files'] == '' }}
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
 
             - name: Get Changed Files
               if: ${{ steps.mode.outputs.mode == 'changes' &&
@@ -265,12 +265,19 @@ jobs:
         outputs:
             directories_to_test: ${{ steps.resolve-directories.outputs.directories_to_test }}
         steps:
+            - name: Check out code
+              if: ${{ inputs['overridden-changed-files'] == '' }}
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
             - name: Determine test mode
               id: mode
               shell: bash
               env:
                   DIRECTORY: ${{ inputs.directory }}
               run: |
+                  echo "Directory input: '$DIRECTORY'"
                   if [ -n "$DIRECTORY" ]; then
                     echo "mode=directory" >> "$GITHUB_OUTPUT"
                     echo "directory=$DIRECTORY" >> "$GITHUB_OUTPUT"
@@ -279,17 +286,10 @@ jobs:
 
                   echo "mode=changes" >> "$GITHUB_OUTPUT"
 
-            - name: Check out code
-              if: ${{ steps.mode.outputs.mode == 'changes' &&
-                  inputs['overridden-changed-files'] == '' }}
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-
             - name: Find Last Successful Checks Run on Branch
               id: last-success
-              if: ${{ steps.mode.outputs.mode == 'changes' && inputs['optimize-base-ref'] ==
-                  'true' && inputs['workflow-name'] != '' }}
+              if: ${{ inputs['optimize-base-ref'] == 'true' && inputs['workflow-name'] != ''
+                  }}
               uses: Now-Micro/actions/get-last-workflow-success-sha@v1
               with:
                   branch: ${{ github.head_ref }}


### PR DESCRIPTION
This pull request refactors the `.github/workflows/reusable-checks.yml` workflow to streamline when code is checked out and adds improved logging for debugging. The main changes involve moving the `actions/checkout` step earlier in the workflow and simplifying conditional logic, as well as adding debug output to the mode determination steps.

Workflow improvements and code checkout logic:

* Moved the `actions/checkout@v6` step to the very beginning of both the "coding standards" and "tests" jobs, ensuring code is checked out before any mode determination or file resolution logic runs. This avoids conditional duplication and simplifies the workflow. [[1]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6R173-R185) [[2]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6R268-R280)
* Removed the redundant conditional `actions/checkout` steps that previously depended on the mode output, further simplifying the workflow logic. [[1]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L187-L193) [[2]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L282-R292)

Debugging and logging enhancements:

* Added echo statements to log the input directory at the start of both the coding standards and test mode determination steps, making it easier to debug workflow runs. [[1]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6R173-R185) [[2]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6R268-R280)

Conditional logic simplification:

* Simplified the conditional for the "Find Last Successful Checks Run on Branch" step by removing the dependency on the mode output, making the step easier to read and maintain.