### PR TITLE
chore: add mention of defaults in the descriptions

### DIFF
--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -25,7 +25,8 @@ on:
                 default: "false"
             # Shared
             ci-debug-mode:
-                description: "Enable verbose debug logging for discovery steps."
+                description: "Enable verbose debug logging for discovery steps. Defaults to
+                    false."
                 required: false
                 type: string
                 default: "false"
@@ -35,7 +36,8 @@ on:
                     respective checks. If you want to check all changed
                     directories, leave this empty and use the respective pattern
                     inputs to specify which files should trigger checks and how
-                    to extract the relevant directories."
+                    to extract the relevant directories. Defaults to empty
+                    (change detection runs across all changed directories)."
                 required: false
                 type: string
                 default: ""
@@ -55,61 +57,65 @@ on:
                 default: "^([^/.]+)/"
             roslyn-version:
                 description: "Optional override for the Microsoft.CodeAnalysis.CSharp package
-                    version used by the analyzers."
+                    version used by the analyzers. Defaults to empty (bundled version is
+                    used)."
                 required: false
                 type: string
                 default: ""
             # Testing - change detection
             optimize-base-ref:
                 description: "When true, compares against the SHA of the last successful run on
-                    this branch instead of the default branch."
+                    this branch instead of the default branch.  Default is true."
                 required: false
                 type: string
-                default: "false"
+                default: "true"
             testing-path-pattern:
                 description: "Regex pattern (with capture group) for identifying changed
-                    directories to run tests against."
+                    directories to run tests against. Defaults to
+                    '^([^/]+)/(?:(src|tests?)/.*\\.(cs|csproj|sln|slnx)|.*\\.(sln|slnx))$'."
                 required: false
                 type: string
                 default: "^([^/]+)/(?:(src|tests?)/.*\\.(cs|csproj|sln|slnx)|.*\\.(sln|slnx))$"
             transformer:
                 description: "sed-style transformer for converting source directories to test
-                    directories."
+                    directories. Defaults to 's#(^|/)src/(.*)$#$1tests/$2.Tests#'."
                 required: false
                 type: string
                 default: "s#(^|/)src/(.*)$#$1tests/$2.Tests#"
             use-original-if-missing:
                 description: "Fall back to the original path if the transformed test directory
-                    does not exist."
+                    does not exist. Defaults to false."
                 required: false
                 type: string
                 default: "false"
             # Testing - run options
             fail-fast:
-                description: "Cancel remaining matrix jobs when any test job fails."
+                description: "Cancel remaining matrix jobs when any test job fails. Defaults
+                    to false."
                 required: false
                 type: string
                 default: "false"
             test-args:
-                description: "Additional arguments passed to dotnet test."
+                description: "Additional arguments passed to dotnet test. Defaults to empty."
                 required: false
                 type: string
                 default: ""
             dotnet-version:
-                description: ".NET SDK version(s) to use when running tests. Comma-separated for
-                    multiple."
+                description: ".NET SDK version(s) to use when running tests. Comma-separated
+                    for multiple. Defaults to empty (uses whatever SDK is available on the
+                    runner)."
                 required: false
                 type: string
                 default: ""
             test-project-regex:
                 description: "Regex to identify the test project file within the test
-                    directory."
+                    directory. Defaults to empty (first .csproj found is used)."
                 required: false
                 type: string
                 default: ""
             prefer-solution:
                 description: "Prefer a .sln file over individual project files when running
-                    tests."
+                    tests. Defaults to false."
                 required: false
                 type: string
                 default: "false"
@@ -118,14 +124,16 @@ on:
                 description: "Filename of this checks workflow. Used when looking up the last
                     successful run for base-ref optimization. If omitted, the
                     workflow will not be able to optimize the base ref and will
-                    always compare against the default branch."
+                    always compare against the default branch. Defaults to empty
+                    (base-ref optimization is disabled)."
                 required: false
                 type: string
                 default: ""
             overridden-changed-files:
                 description: "JSON array of file paths to treat as changed. When set, skips git
                     change detection entirely and uses these paths for pattern
-                    matching. Intended for testing and demo scenarios."
+                    matching. Intended for testing and demo scenarios. Defaults to
+                    empty (git change detection is used)."
                 required: false
                 type: string
                 default: ""

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -105,11 +105,10 @@ on:
                 default: ""
             dotnet-version:
                 description: ".NET SDK version(s) to use when running tests. Comma-separated for
-                    multiple. Defaults to empty (uses whatever SDK is available
-                    on the runner)."
+                    multiple. Defaults to 8.0.x."
                 required: false
                 type: string
-                default: ""
+                default: "8.0.x"
             test-project-regex:
                 description: "Regex to identify the test project file within the test directory.
                     Defaults to empty (first .csproj found is used)."

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -57,28 +57,31 @@ on:
                 default: "^([^/.]+)/"
             roslyn-version:
                 description: "Optional override for the Microsoft.CodeAnalysis.CSharp package
-                    version used by the analyzers. Defaults to empty (bundled version is
-                    used)."
+                    version used by the analyzers. Defaults to empty (bundled
+                    version is used)."
                 required: false
                 type: string
                 default: ""
             # Testing - change detection
             optimize-base-ref:
                 description: "When true, compares against the SHA of the last successful run on
-                    this branch instead of the default branch.  Default is false."
+                    this branch instead of the default branch.  Default is
+                    false."
                 required: false
                 type: string
                 default: "false"
             testing-path-pattern:
                 description: "Regex pattern (with capture group) for identifying changed
                     directories to run tests against. Defaults to
-                    '^([^/]+)/(?:(src|tests?)/.*\\.(cs|csproj|sln|slnx)|.*\\.(sln|slnx))$'."
+                    '^([^/]+)/(?:(src|tests?)/.*\\.(cs|csproj|sln|slnx)|.*\\.(s\
+                    ln|slnx))$'."
                 required: false
                 type: string
                 default: "^([^/]+)/(?:(src|tests?)/.*\\.(cs|csproj|sln|slnx)|.*\\.(sln|slnx))$"
             transformer:
                 description: "sed-style transformer for converting source directories to test
-                    directories. Defaults to 's#(^|/)src/(.*)$#$1tests/$2.Tests#'."
+                    directories. Defaults to
+                    's#(^|/)src/(.*)$#$1tests/$2.Tests#'."
                 required: false
                 type: string
                 default: "s#(^|/)src/(.*)$#$1tests/$2.Tests#"
@@ -90,8 +93,8 @@ on:
                 default: "false"
             # Testing - run options
             fail-fast:
-                description: "Cancel remaining matrix jobs when any test job fails. Defaults
-                    to false."
+                description: "Cancel remaining matrix jobs when any test job fails. Defaults to
+                    false."
                 required: false
                 type: string
                 default: "false"
@@ -101,15 +104,15 @@ on:
                 type: string
                 default: ""
             dotnet-version:
-                description: ".NET SDK version(s) to use when running tests. Comma-separated
-                    for multiple. Defaults to empty (uses whatever SDK is available on the
-                    runner)."
+                description: ".NET SDK version(s) to use when running tests. Comma-separated for
+                    multiple. Defaults to empty (uses whatever SDK is available
+                    on the runner)."
                 required: false
                 type: string
                 default: ""
             test-project-regex:
-                description: "Regex to identify the test project file within the test
-                    directory. Defaults to empty (first .csproj found is used)."
+                description: "Regex to identify the test project file within the test directory.
+                    Defaults to empty (first .csproj found is used)."
                 required: false
                 type: string
                 default: ""
@@ -132,8 +135,8 @@ on:
             overridden-changed-files:
                 description: "JSON array of file paths to treat as changed. When set, skips git
                     change detection entirely and uses these paths for pattern
-                    matching. Intended for testing and demo scenarios. Defaults to
-                    empty (git change detection is used)."
+                    matching. Intended for testing and demo scenarios. Defaults
+                    to empty (git change detection is used)."
                 required: false
                 type: string
                 default: ""
@@ -172,7 +175,7 @@ jobs:
                     exit 1
                   fi
                   echo "✅ token-github-packages secret is present."
-            
+
             - name: Check out code
               uses: actions/checkout@v6
               with:
@@ -305,6 +308,7 @@ jobs:
               uses: Now-Micro/actions/get-last-workflow-success-sha@v1
               with:
                   branch: ${{ github.head_ref }}
+                  debug-mode: ${{ inputs['ci-debug-mode'] }}
                   default-branch: ${{ github.event.repository.default_branch }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   job-names-that-must-succeed: "test"

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -65,10 +65,10 @@ on:
             # Testing - change detection
             optimize-base-ref:
                 description: "When true, compares against the SHA of the last successful run on
-                    this branch instead of the default branch.  Default is true."
+                    this branch instead of the default branch.  Default is false."
                 required: false
                 type: string
-                default: "true"
+                default: "false"
             testing-path-pattern:
                 description: "Regex pattern (with capture group) for identifying changed
                     directories to run tests against. Defaults to


### PR DESCRIPTION
This pull request updates the documentation for several workflow inputs in the `.github/workflows/reusable-checks.yml` file to clarify their default values and behaviors. It also changes the default value of the `optimize-base-ref` input from `"false"` to `"true"`. The most important changes are grouped below:

**Documentation Improvements:**

* Added explicit descriptions of default values for many workflow inputs, such as `ci-debug-mode`, `changed-dirs`, `roslyn-version`, `testing-path-pattern`, `transformer`, `use-original-if-missing`, `fail-fast`, `test-args`, `dotnet-version`, `test-project-regex`, `prefer-solution`, `checks-workflow-filename`, and `overridden-changed-files`, making it clearer for users what happens when these inputs are omitted. [[1]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L28-R29) [[2]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L38-R40) [[3]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L58-R118) [[4]](diffhunk://#diff-08e079994450c9d01227fdd091ed3530fe6f89c94310aedf52451f1d319f5be6L121-R136)

**Behavioral Change:**

* Changed the default value of the `optimize-base-ref` input from `"false"` to `"true"`, so the workflow will now, by default, compare against the SHA of the last successful run on the branch instead of the default branch.

These changes improve the clarity and usability of the workflow configuration for contributors and maintainers.