### PR TITLE
fix(reusable-checks.yml): issue with caller's job name prefix

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -138,12 +138,31 @@ Runs the repo's shared PR checks: linting, coding standards, and tests. It is de
 | `test-project-regex` | No | `""` | Regex used to identify the test project file. |
 | `prefer-solution` | No | `false` | Prefer a solution file over individual projects for testing. |
 | `workflow-name` | No | `""` | Workflow filename used when looking up the last successful run for optimization. |
+| `caller-job-name` | No | `""` | The name of the job in the calling workflow that invokes this reusable workflow (e.g. `checks`). Required when `optimize-base-ref` is `true`. GitHub prefixes every job name in the API response with the caller's job name (e.g. `checks / test-setup`), so this must be provided for the last-successful-run lookup to match correctly. See [Base-ref optimization](#base-ref-optimization) below. |
+| `overridden-changed-files` | No | `""` | JSON array of file paths to treat as changed. Skips git change detection entirely. Intended for testing and demo scenarios. |
 
 **Secrets**
 
 | Name | Required | Description |
 |---|---|---|
 | `token-github-packages` | No | Optionally required depending on project.  PAT with `read:packages` permission for restoring NuGet packages from GitHub Packages. |
+
+**Base-ref optimization**
+
+When `optimize-base-ref: "true"` and `workflow-name` is set, the `test-setup` job compares changed files against the SHA of the last successful run on the branch (rather than the default branch), so tests only run for files that have changed since the last green build.
+
+Because the workflow is called as a reusable workflow, GitHub prefixes all job names in the API with the caller's job name. For example, if your calling job is named `checks`, the API reports jobs as `checks / test-setup`, `checks / test (...)`. The lookup will fail to find any matching runs unless you also pass `caller-job-name: "checks"` to tell the workflow what prefix to expect.
+
+```yaml
+jobs:
+  checks:
+    uses: Now-Micro/actions/.github/workflows/reusable-checks.yml@v1
+    with:
+      optimize-base-ref: "true"
+      workflow-name: checks.yml
+      caller-job-name: checks   # must match the job key above
+      ...
+```
 
 **Usage — called from a PR workflow**
 
@@ -152,11 +171,13 @@ jobs:
   checks:
     uses: Now-Micro/actions/.github/workflows/reusable-checks.yml@v1
     with:
+      caller-job-name: checks
       dotnet-version: "8.0.x"
       enable-linting: "true"
       enable-coding-standards: "true"
       enable-testing: "true"
       head-ref: ${{ github.event.pull_request.head.sha }}
+      optimize-base-ref: "true"
       roslyn-version: "4.9.2"
       test-project-regex: '.*Tests\.csproj\s*$'
       workflow-name: checks.yml
@@ -171,6 +192,7 @@ jobs:
   checks:
     uses: Now-Micro/actions/.github/workflows/reusable-checks.yml@v1
     with:
+      caller-job-name: checks
       ci-debug-mode: ${{ vars.ENABLE_TEST_DEBUGGING }}
       directory: "./" # this is the trigger to change the mode
       prefer-solution: "true" # test the solution file

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -312,7 +312,7 @@ jobs:
 
             - name: Find Last Successful Checks Run on Branch
               id: last-success
-              if: ${{ inputs['optimize-base-ref'] == 'true' && inputs['workflow-name'] != ''
+              if: ${{ inputs['optimize-base-ref'] == 'true' && inputs['workflow-name'] != '' && inputs['caller-job-name'] != ''
                   }}
               uses: Now-Micro/actions/get-last-workflow-success-sha@v1
               with:

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -128,10 +128,10 @@ on:
                     name (`jobs.<id>.name`) when it is set; otherwise pass the
                     job id/YAML key (`jobs.<id>`). You can find the exact value
                     in the GitHub Actions UI/API job name. Required when
-                    optimize-base-ref is true. GitHub prefixes reusable
-                    workflow job names with this value (e.g. 'checks /
-                    test-setup'), so it must match for the last-success lookup
-                    to work correctly. Defaults to empty."
+                    optimize-base-ref is true. GitHub prefixes reusable workflow
+                    job names with this value (e.g. 'checks / test-setup'), so
+                    it must match for the last-success lookup to work correctly.
+                    Defaults to empty."
                 required: false
                 type: string
                 default: ""
@@ -315,8 +315,8 @@ jobs:
 
             - name: Find Last Successful Checks Run on Branch
               id: last-success
-              if: ${{ inputs['optimize-base-ref'] == 'true' && inputs['workflow-name'] != '' && inputs['caller-job-name'] != ''
-                  }}
+              if: ${{ inputs['optimize-base-ref'] == 'true' && inputs['workflow-name'] != ''
+                  && inputs['caller-job-name'] != '' }}
               uses: Now-Micro/actions/get-last-workflow-success-sha@v1
               with:
                   branch: ${{ github.head_ref }}

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -122,12 +122,13 @@ on:
                 type: string
                 default: "false"
             # Other
-            workflow-name:
-                description: "Filename of this checks workflow. Used when looking up the last
-                    successful run for base-ref optimization. If omitted, the
-                    workflow will not be able to optimize the base ref and will
-                    always compare against the default branch. Defaults to empty
-                    (base-ref optimization is disabled)."
+            caller-job-name:
+                description: "The name of the job in the calling workflow that invokes this
+                    reusable workflow (e.g. 'checks'). Required when
+                    optimize-base-ref is true. GitHub prefixes all reusable
+                    workflow job names with this value in the API (e.g. 'checks
+                    / test-setup'), so it must be provided for the last-success
+                    lookup to match correctly. Defaults to empty."
                 required: false
                 type: string
                 default: ""
@@ -136,6 +137,15 @@ on:
                     change detection entirely and uses these paths for pattern
                     matching. Intended for testing and demo scenarios. Defaults
                     to empty (git change detection is used)."
+                required: false
+                type: string
+                default: ""
+            workflow-name:
+                description: "Filename of this checks workflow. Used when looking up the last
+                    successful run for base-ref optimization. If omitted, the
+                    workflow will not be able to optimize the base ref and will
+                    always compare against the default branch. Defaults to empty
+                    (base-ref optimization is disabled)."
                 required: false
                 type: string
                 default: ""
@@ -310,8 +320,10 @@ jobs:
                   debug-mode: ${{ inputs['ci-debug-mode'] }}
                   default-branch: ${{ github.event.repository.default_branch }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  job-names-that-must-succeed: "test"
-                  main-job-name: "test-setup"
+                  job-names-that-must-succeed: ${{ inputs['caller-job-name'] != '' && format('{0}
+                      / test', inputs['caller-job-name']) || 'test' }}
+                  main-job-name: ${{ inputs['caller-job-name'] != '' && format('{0} / test-setup',
+                      inputs['caller-job-name']) || 'test-setup' }}
                   request-size: 50
                   retry-attempts: 3
                   workflow-name: ${{ inputs['workflow-name'] }}

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -123,12 +123,15 @@ on:
                 default: "false"
             # Other
             caller-job-name:
-                description: "The name of the job in the calling workflow that invokes this
-                    reusable workflow (e.g. 'checks'). Required when
-                    optimize-base-ref is true. GitHub prefixes all reusable
-                    workflow job names with this value in the API (e.g. 'checks
-                    / test-setup'), so it must be provided for the last-success
-                    lookup to match correctly. Defaults to empty."
+                description: "The calling workflow job name prefix used by GitHub for this
+                    reusable workflow invocation. Pass the calling job's display
+                    name (`jobs.<id>.name`) when it is set; otherwise pass the
+                    job id/YAML key (`jobs.<id>`). You can find the exact value
+                    in the GitHub Actions UI/API job name. Required when
+                    optimize-base-ref is true. GitHub prefixes reusable
+                    workflow job names with this value (e.g. 'checks /
+                    test-setup'), so it must match for the last-success lookup
+                    to work correctly. Defaults to empty."
                 required: false
                 type: string
                 default: ""


### PR DESCRIPTION
This pull request updates the `.github/workflows/reusable-checks.yml` workflow to improve support for reusable workflows, particularly around job naming and base-ref optimization. The main changes clarify and rework how job and workflow names are passed and used, making the workflow more flexible and compatible with GitHub's API conventions.

**Inputs and job naming improvements:**

* Replaced the `workflow-name` input with a new `caller-job-name` input, which specifies the name of the job in the calling workflow that invokes this reusable workflow. This change ensures correct job name matching for last-successful-run lookups, especially when base-ref optimization is enabled. (`.github/workflows/reusable-checks.yml`)
* Re-added the `workflow-name` input (now after `caller-job-name`) to allow specifying the workflow filename for base-ref optimization, maintaining backward compatibility and flexibility. (`.github/workflows/reusable-checks.yml`)

**Job configuration logic:**

* Updated the values for `job-names-that-must-succeed` and `main-job-name` to dynamically include the `caller-job-name` prefix when provided, matching GitHub's naming conventions for reusable workflow jobs. This ensures accurate job identification and improves reliability of success checks. (`.github/workflows/reusable-checks.yml`)