### PR TITLE
chore: use authorize in reusable nuget-publish workflow

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -62,6 +62,9 @@ jobs:
     nuget-publish:
         runs-on: ubuntu-22.04
         steps:
+            - name: Authorize workflow
+              uses: Now-Micro/actions/authorize@v1
+
             - name: Check out code
               uses: actions/checkout@v6
               with:

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -64,6 +64,8 @@ jobs:
         steps:
             - name: Authorize workflow
               uses: Now-Micro/actions/authorize@v1
+              with:
+                debug-mode: ${{ inputs['ci-debug-mode'] != '' && inputs['ci-debug-mode'] || 'false' }}
 
             - name: Check out code
               uses: actions/checkout@v6


### PR DESCRIPTION
This pull request introduces an authorization step to the NuGet publish workflow to improve security and control over workflow execution.

Enhancements to workflow security:

* Added a new "Authorize workflow" step at the beginning of the `nuget-publish` job in `.github/workflows/nuget-publish.yml`, utilizing the `Now-Micro/actions/authorize@v1` action with configurable debug mode.