### PR TITLE
chore: use solution regex in reusable checks

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -122,7 +122,7 @@ Runs the repo's shared PR checks: linting, coding standards, and tests. It is de
 | `use-original-if-missing` | No | `false` | Keep the original path when the transformed test directory does not exist. |
 | `fail-fast` | No | `false` | Cancel remaining test matrix jobs when one fails. |
 | `test-args` | No | `""` | Additional arguments passed to `dotnet test`. |
-| `dotnet-version` | No | `"8.0.x"` | .NET SDK version(s) to use when running tests. |
+| `dotnet-version` | No | `8.0.x` | .NET SDK version(s) to use when running tests. |
 | `test-project-regex` | No | `""` | Regex used to identify the test project file. |
 | `solution-regex` | No | `""` | Regex used to identify the solution file. |
 | `prefer-solution` | No | `false` | Prefer a solution file over individual projects for testing. |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,8 +10,26 @@ This directory contains GitHub Actions **reusable workflows** — shared workflo
   - [When to use which](#when-to-use-which)
 - [Reusable Workflows in this Repo](#reusable-workflows-in-this-repo)
   - [Reusable Checks Workflow](#reusable-checks-workflow)
+    - [What it does](#reusable-checks-what-it-does)
+    - [Inputs](#reusable-checks-inputs)
+    - [Secrets](#reusable-checks-secrets)
+    - [Base-ref optimization](#reusable-checks-base-ref-optimization)
+    - [Usage - called from a PR workflow](#reusable-checks-usage---called-from-a-pr-workflow)
+    - [Usage - check one directory explicitly](#reusable-checks-usage---check-one-directory-explicitly)
   - [NuGet Publish Workflow](#nuget-publish-workflow)
+    - [What it does](#nuget-publish-what-it-does)
+    - [Trigger](#nuget-publish-trigger)
+    - [Inputs](#nuget-publish-inputs)
+    - [Secrets](#nuget-publish-secrets)
+    - [Single Directory Case](#nuget-publish-usage---called-from-another-workflow)
+    - [Multi-Directory Case](#nuget-publish-usage---automatic-trigger-on-release-branch-push)
   - [Pre-Release NuGet Workflow](#pre-release-nuget-workflow)
+    - [What it does](#pre-release-nuget-what-it-does)
+    - [Inputs](#pre-release-nuget-inputs)
+    - [Secrets](#pre-release-nuget-secrets)
+    - [Usage - auto-detect changed packages on a PR](#pre-release-nuget-usage---auto-detect-changed-packages-on-a-pr)
+    - [Usage - publish a specific directory](#pre-release-nuget-usage---publish-a-specific-directory)
+    - [Version format](#pre-release-nuget-version-format)
 
 ---
 
@@ -78,7 +96,7 @@ steps:
 
 Runs the repo's shared PR checks: linting, coding standards, and tests. It is designed to be called from PR workflows so consumers can pass in the branch context and, optionally, a specific directory to check.
 
-#### What it does
+#### Reusable Checks What it does
 
 1. Runs CSharpier linting when `enable-linting` is `true`.
 2. Resolves the directories to check for coding standards and tests.
@@ -86,7 +104,7 @@ Runs the repo's shared PR checks: linting, coding standards, and tests. It is de
 4. Runs tests for each resolved directory.
 5. Uploads test result artifacts for each test matrix entry.
 
-#### Inputs
+#### Reusable Checks Inputs
 
 | Name | Required | Default | Description |
 |---|---|---|---|
@@ -106,18 +124,19 @@ Runs the repo's shared PR checks: linting, coding standards, and tests. It is de
 | `test-args` | No | `""` | Additional arguments passed to `dotnet test`. |
 | `dotnet-version` | No | `""` | .NET SDK version(s) to use when running tests. |
 | `test-project-regex` | No | `""` | Regex used to identify the test project file. |
+| `solution-regex` | No | `""` | Regex used to identify the solution file. |
 | `prefer-solution` | No | `false` | Prefer a solution file over individual projects for testing. |
 | `workflow-name` | No | `""` | Workflow filename used when looking up the last successful run for optimization. |
 | `caller-job-name` | No | `""` | The name of the job in the calling workflow that invokes this reusable workflow (e.g. `checks`). Required when `optimize-base-ref` is `true`. GitHub prefixes every job name in the API response with the caller's job name (e.g. `checks / test-setup`), so this must be provided for the last-successful-run lookup to match correctly. See [Base-ref optimization](#base-ref-optimization) below. |
 | `overridden-changed-files` | No | `""` | JSON array of file paths to treat as changed. Skips git change detection entirely. Intended for testing and demo scenarios. |
 
-#### Secrets
+#### Reusable Checks Secrets
 
 | Name | Required | Description |
 |---|---|---|
 | `token-github-packages` | No | Optionally required depending on project.  PAT with `read:packages` permission for restoring NuGet packages from GitHub Packages. |
 
-#### Base-ref optimization
+#### Reusable Checks Base-ref optimization
 
 When `optimize-base-ref: "true"` and `workflow-name` is set, the `test-setup` job compares changed files against the SHA of the last successful run on the branch (rather than the default branch), so tests only run for files that have changed since the last green build.
 
@@ -134,7 +153,7 @@ jobs:
       ...
 ```
 
-#### Usage — called from a PR workflow
+#### Single Directory Case:
 
 ```yaml
 jobs:
@@ -155,7 +174,7 @@ jobs:
       token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
 ```
 
-#### Usage — check one directory explicitly
+#### Multi-Directory Case:
 
 ```yaml
 jobs:
@@ -184,7 +203,7 @@ jobs:
 
 Builds, packs, and publishes a versioned NuGet package from a release branch, then creates a GitHub release with the generated artifacts. Intended to run automatically when a `release/**` branch is pushed, or to be called explicitly from another workflow.
 
-#### What it does
+#### NuGet Publish What it does
 
 1. Checks out the repository.
 2. Validates the release ref and extracts the package name and version from it.
@@ -193,11 +212,11 @@ Builds, packs, and publishes a versioned NuGet package from a release branch, th
 5. Builds and packs the project, running tests if a test directory is specified.
 6. Uploads artifacts and creates a GitHub release with release notes.
 
-#### Trigger
+#### NuGet Publish Trigger
 
 Runs automatically on `push` to any `release/**` branch, or on `workflow_call`.
 
-#### Inputs
+#### NuGet Publish Inputs
 
 | Name | Required | Default | Description |
 |---|---|---|---|
@@ -213,13 +232,13 @@ Runs automatically on `push` to any `release/**` branch, or on `workflow_call`.
 | `tests-directory` | No | — | Directory containing the test project. Leave empty to skip tests. |
 | `version` | No | — | Explicit version to publish. Extracted from `ref-name` when empty. |
 
-#### Secrets
+#### NuGet Publish Secrets
 
 | Name | Required | Description |
 |---|---|---|
 | `token-github-packages` | Yes | PAT with `read:packages` and `write:packages` permissions for pushing to GitHub Packages. |
 
-#### Usage — called from another workflow
+#### NuGet Publish Usage - called from another workflow
 
 ```yaml
 jobs:
@@ -233,7 +252,7 @@ jobs:
       token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
 ```
 
-#### Usage — automatic trigger on release branch push
+#### NuGet Publish Usage - automatic trigger on release branch push
 
 Simply push or merge to a branch named `release/MyLibrary/1.2.3`. The workflow will pick up the package name (`MyLibrary`) and version (`1.2.3`) from the branch name automatically.
 
@@ -248,7 +267,7 @@ git push origin release/MyLibrary/1.2.3
 
 Detects which project directories have changed and publishes a timestamped pre-release NuGet package for each one. Designed to be called on pull requests or feature branches to publish an `alpha`/`beta`/`rc`/`preview` build that consumers can test before a full release.
 
-#### What it does
+#### Pre-Release NuGet What it does
 
 When `directory` is **not** provided:
 
@@ -267,7 +286,7 @@ In both cases, for each directory:
 3. Builds, packs, and pushes the package to the NuGet feed.
 4. Uploads the artifacts and generates a pre-release summary.
 
-#### Inputs
+#### Pre-Release NuGet Inputs
 
 | Name | Required | Default | Description |
 |---|---|---|---|
@@ -283,13 +302,13 @@ In both cases, for each directory:
 | `prerelease-identifier` | No | `alpha` | Label to embed in the version string (`alpha`, `beta`, `preview`, `rc`). |
 | `version-increment-type` | No | `none` | How to increment the version (`major`, `minor`, `patch`, or `none`). |
 
-#### Secrets
+#### Pre-Release NuGet Secrets
 
 | Name | Required | Description |
 |---|---|---|
 | `token-github-packages` | Yes | PAT with `read:packages` and `write:packages` permissions. |
 
-#### Usage — auto-detect changed packages on a PR
+#### Pre-Release NuGet Usage - auto-detect changed packages on a PR
 
 ```yaml
 jobs:
@@ -304,7 +323,7 @@ jobs:
       token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
 ```
 
-#### Usage — publish a specific directory
+#### Pre-Release NuGet Usage - publish a specific directory
 
 ```yaml
 jobs:
@@ -319,7 +338,7 @@ jobs:
       token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
 ```
 
-#### Version format
+#### Pre-Release NuGet Version format
 
 Pre-release versions follow the pattern:
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -153,7 +153,7 @@ jobs:
       ...
 ```
 
-#### Single Directory Case:
+#### Single Directory Case
 
 ```yaml
 jobs:
@@ -174,7 +174,7 @@ jobs:
       token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
 ```
 
-#### Multi-Directory Case:
+#### Multi-Directory Case
 
 ```yaml
 jobs:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -122,7 +122,7 @@ Runs the repo's shared PR checks: linting, coding standards, and tests. It is de
 | `use-original-if-missing` | No | `false` | Keep the original path when the transformed test directory does not exist. |
 | `fail-fast` | No | `false` | Cancel remaining test matrix jobs when one fails. |
 | `test-args` | No | `""` | Additional arguments passed to `dotnet test`. |
-| `dotnet-version` | No | `""` | .NET SDK version(s) to use when running tests. |
+| `dotnet-version` | No | `"8.0.x"` | .NET SDK version(s) to use when running tests. |
 | `test-project-regex` | No | `""` | Regex used to identify the test project file. |
 | `solution-regex` | No | `""` | Regex used to identify the solution file. |
 | `prefer-solution` | No | `false` | Prefer a solution file over individual projects for testing. |

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -139,12 +139,6 @@ on:
                 required: false
                 type: string
                 default: ""
-            solution-regex:
-                description: "Regex to identify the solution file to use for testing.
-                    Defaults to empty (first .sln found is used)."
-                required: false
-                type: string
-                default: ""
             prefer-solution:
                 description: "Prefer a .sln file over individual project files when running
                     tests. Defaults to false."
@@ -460,7 +454,6 @@ jobs:
                   dotnet-version: ${{ inputs['dotnet-version'] }}
                   project-regex: ${{ inputs['test-project-regex'] }}
                   prefer-solution: ${{ inputs['prefer-solution'] }}
-                  solution-regex: ${{ inputs['solution-regex'] }}
 
             - name: Build safe artifact name
               id: artifact-name

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -141,7 +141,7 @@ on:
                 default: ""
             solution-regex:
                 description: "Regex to identify the solution file to use for testing.
-                    Defaults to empty (first .sln found is used)."
+                    Defaults to empty (first solution file found, such as .sln or .slnx, is used)."
                 required: false
                 type: string
                 default: ""

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -139,6 +139,12 @@ on:
                 required: false
                 type: string
                 default: ""
+            solution-regex:
+                description: "Regex to identify the solution file to use for testing.
+                    Defaults to empty (first .sln found is used)."
+                required: false
+                type: string
+                default: ""
             prefer-solution:
                 description: "Prefer a .sln file over individual project files when running
                     tests. Defaults to false."
@@ -454,6 +460,7 @@ jobs:
                   dotnet-version: ${{ inputs['dotnet-version'] }}
                   project-regex: ${{ inputs['test-project-regex'] }}
                   prefer-solution: ${{ inputs['prefer-solution'] }}
+                  solution-regex: ${{ inputs['solution-regex'] }}
 
             - name: Build safe artifact name
               id: artifact-name

--- a/dotnet/test/README.md
+++ b/dotnet/test/README.md
@@ -10,5 +10,6 @@ This action finds a .NET project or solution when needed, installs the requested
   with:
     directory: src/MyApp.Tests
     dotnet-version: 8.0.x
+    prefer-solution: "true"
     solution-regex: '.*\.sln$'
 ```

--- a/dotnet/test/README.md
+++ b/dotnet/test/README.md
@@ -10,4 +10,5 @@ This action finds a .NET project or solution when needed, installs the requested
   with:
     directory: src/MyApp.Tests
     dotnet-version: 8.0.x
+    solution-regex: '.*\.sln$'
 ```

--- a/dotnet/test/action.yml
+++ b/dotnet/test/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: "Regular expression to identify project file desired.  If empty, will return the first .csproj file found when find-project is true."
     required: false
     default: ""
+  solution-regex:
+    description: "Regular expression to identify solution file desired.  If empty, will return the first .sln file found when find-solution is true."
+    required: false
+    default: ""
   project-file:
     description: "Path to the project file. If specified, this will be used instead of searching the directory for a .csproj or .sln file."
     required: false
@@ -65,6 +69,7 @@ runs:
         find-project: true
         find-solution: true
         project-regex: ${{ inputs.project-regex }}
+        solution-regex: ${{ inputs.solution-regex }}
 
     - name: Resolve project or solution
       id: resolve-target


### PR DESCRIPTION
This pull request updates the configuration and documentation for the .NET test workflow, focusing on improving flexibility in solution file selection and updating the default .NET SDK version. The most important changes are:

**Workflow Input Enhancements:**

* Added a new `solution-regex` input to `.github/workflows/reusable-checks.yml`, allowing users to specify a regex pattern to identify which solution file to use for testing. This input defaults to an empty string, meaning the first `.sln` file found will be used if not specified.
* Updated the workflow to pass the new `solution-regex` input to the test action, ensuring the regex is used during test execution.

**Documentation Updates:**

* Updated `.github/workflows/README.md` to document the new `solution-regex` input and set the default value of `dotnet-version` to `"8.0.x"` instead of an empty string, reflecting the current recommended .NET SDK version.
* Updated the usage example in `dotnet/test/README.md` to include the new `prefer-solution` and `solution-regex` inputs, demonstrating how to use the new functionality.