### PR TITLE
chore: update actions for releasing to take in nuget-names too

### DIFF
--- a/.github/actions/demo-pre-release-workflow/action.yml
+++ b/.github/actions/demo-pre-release-workflow/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: "The .NET version(s) to install, comma-separated (e.g. '8.0.x,10.0.x')."
     required: false
     default: "8.0.x"
+  nuget-names:
+    description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
+    required: false
+    default: "Now-Micro"
   nuget-urls:
     description: "NuGet feed URL to publish to."
     required: false
@@ -57,6 +61,7 @@ runs:
         ci-debug-mode: ${{ inputs['ci-debug-mode'] }}
         directory: ${{ inputs['directory'] }}
         dotnet-version: ${{ inputs['dotnet-version'] }}
+        nuget-names: ${{ inputs['nuget-names'] }}
         nuget-urls: ${{ inputs['nuget-urls'] }}
         prerelease-identifier: ${{ inputs['prerelease-identifier'] }}
         token-github-packages: ${{ inputs['token-github-packages'] }}

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: "Ignore casing when parsing release refs and matching package names."
     required: false
     default: "true"
+  nuget-names:
+    description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
+    required: false
+    default: "GitHub"
   nuget-urls:
     description: "Nuget feed URLs needed to build the projects. Should be a comma-separated list of URLs."
     required: false
@@ -172,7 +176,7 @@ runs:
         additional-pack-args: /p:PackageVersion=${{ steps.get-version.outputs.version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg
         dotnet-version: ${{ inputs['release-dotnet-version'] }}
         github-token: ${{ inputs['token-github-packages'] }}
-        nuget-names: "github"
+        nuget-names: ${{ inputs['nuget-names'] }}
         nuget-passwords: ${{ inputs['token-github-packages'] }}
         nuget-urls: ${{ inputs['nuget-urls'] }}
         nuget-usernames: ${{ github.actor }}

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -29,7 +29,7 @@ inputs:
   nuget-names:
     description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
     required: false
-    default: "GitHub"
+    default: "Now-Micro"
   nuget-urls:
     description: "Nuget feed URLs needed to build the projects. Should be a comma-separated list of URLs."
     required: false

--- a/.github/actions/nuget-publish-workflow/action.yml
+++ b/.github/actions/nuget-publish-workflow/action.yml
@@ -33,7 +33,7 @@ inputs:
   nuget-urls:
     description: "Nuget feed URLs needed to build the projects. Should be a comma-separated list of URLs."
     required: false
-    default: ""
+    default: "https://nuget.pkg.github.com/Now-Micro/index.json"
   package:
     description: "Package name to release."
     required: false

--- a/.github/actions/reusable-pre-release-workflow/action.yml
+++ b/.github/actions/reusable-pre-release-workflow/action.yml
@@ -45,7 +45,7 @@ inputs:
   nuget-urls:
     description: "Nuget feed URLs needed to build the projects.  Should be a comma-separated list of URLs."
     required: false
-    default: ""
+    default: "https://nuget.pkg.github.com/Now-Micro/index.json"
   prerelease-identifier:
     description: "Pre-release identifier (alpha, beta, preview, rc)"
     required: false

--- a/.github/actions/reusable-pre-release-workflow/action.yml
+++ b/.github/actions/reusable-pre-release-workflow/action.yml
@@ -25,7 +25,7 @@ inputs:
   nuget-names:
     description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
     required: false
-    default: "GitHub"
+    default: "Now-Micro"
   nuget-package-dir:
     description: "Directory to store generated package artifacts."
     required: false

--- a/.github/actions/reusable-pre-release-workflow/action.yml
+++ b/.github/actions/reusable-pre-release-workflow/action.yml
@@ -22,6 +22,10 @@ inputs:
       Should be a comma-separated list of versions (e.g. '8.0.x,10.0.x')."
     required: false
     default: "8.0.x"
+  nuget-names:
+    description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
+    required: false
+    default: "GitHub"
   nuget-package-dir:
     description: "Directory to store generated package artifacts."
     required: false
@@ -130,7 +134,7 @@ runs:
           -p:SymbolPackageFormat=snupkg
         dotnet-version: ${{ inputs.dotnet-version }}
         github-token: ${{ inputs.token-github-packages }}
-        nuget-names: "github"
+        nuget-names: ${{ inputs['nuget-names'] }}
         nuget-passwords: ${{ inputs.token-github-packages }}
         nuget-urls: ${{ inputs.nuget-urls }}
         nuget-usernames: ${{ github.actor }}

--- a/.github/workflows/demo-pre-release.yml
+++ b/.github/workflows/demo-pre-release.yml
@@ -33,11 +33,16 @@ on:
                 required: false
                 type: string
                 default: "8.0.x"
+            nuget-names:
+                description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
+                required: false
+                type: string
+                default: "Now-Micro"
             nuget-urls:
                 description: "NuGet feed URLs needed to build the projects. Should be a comma-separated list of URLs."
                 required: false
                 type: string
-                default: ""
+                default: "https://nuget.pkg.github.com/Now-Micro/index.json"
             prerelease-identifier:
                 description: "Pre-release identifier."
                 required: false
@@ -80,6 +85,7 @@ jobs:
                   delete-published-package: ${{ inputs['delete-published-package'] }}
                   directory: ${{ inputs['directory'] }}
                   dotnet-version: ${{ inputs['dotnet-version'] }}
+                  nuget-names: ${{ inputs['nuget-names'] }}
                   nuget-urls: ${{ inputs['nuget-urls'] }}
                   prerelease-identifier: ${{ inputs['prerelease-identifier'] }}
                   token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -25,10 +25,12 @@ on:
                 description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
                 required: false
                 type: string
+                default: "Now-Micro"
             nuget-urls:
                 description: "Nuget feed URLs needed to build the projects. Should be a comma-separated list of URLs."
                 required: false
                 type: string
+                default: "https://nuget.pkg.github.com/Now-Micro/index.json"
             package:
                 description: "Package name to release."
                 required: false

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -21,6 +21,10 @@ on:
                 description: "Ignore casing when parsing release refs and matching package names."
                 required: false
                 type: string
+            nuget-names:
+                description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
+                required: false
+                type: string
             nuget-urls:
                 description: "Nuget feed URLs needed to build the projects. Should be a comma-separated list of URLs."
                 required: false
@@ -65,7 +69,7 @@ jobs:
             - name: Authorize workflow
               uses: Now-Micro/actions/authorize@v1
               with:
-                debug-mode: ${{ inputs['ci-debug-mode'] != '' && inputs['ci-debug-mode'] || 'false' }}
+                  debug-mode: ${{ inputs['ci-debug-mode'] != '' && inputs['ci-debug-mode'] || 'false' }}
 
             - name: Check out code
               uses: actions/checkout@v6
@@ -80,6 +84,7 @@ jobs:
                   cleanup-release: "false"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   ignore-casing: ${{ inputs['ignore-casing'] != '' && inputs['ignore-casing'] || 'true' }}
+                  nuget-names: ${{ inputs['nuget-names'] }}
                   nuget-urls: ${{ inputs['nuget-urls'] }}
                   package: ${{ inputs.package }}
                   package-directory: ${{ inputs['package-directory'] != '' && inputs['package-directory'] || 'nupkgs' }}

--- a/.github/workflows/reusable-pre-release.yml
+++ b/.github/workflows/reusable-pre-release.yml
@@ -88,7 +88,6 @@ jobs:
             - name: Validate inputs
               shell: bash
               env:
-                  NUGET_URLS: ${{ inputs['nuget-urls'] }}
                   TOKEN_GITHUB_PACKAGES: ${{ secrets['token-github-packages'] }}
               run: |
                   valid_identifiers="alpha beta preview rc"
@@ -96,11 +95,6 @@ jobs:
 
                   identifier="${{ inputs['prerelease-identifier'] }}"
                   increment="${{ inputs['version-increment-type'] }}"
-
-                  if [[ -z "$NUGET_URLS" ]]; then
-                    echo "❌ Required input 'nuget-urls' is empty."
-                    exit 1
-                  fi
 
                   if [[ -z "$TOKEN_GITHUB_PACKAGES" ]]; then
                     echo "❌ Required secret 'token-github-packages' is empty."

--- a/.github/workflows/reusable-pre-release.yml
+++ b/.github/workflows/reusable-pre-release.yml
@@ -45,7 +45,7 @@ on:
                 description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
                 required: false
                 type: string
-                default: ""
+                default: "Now-Micro"
             nuget-pattern-to-match:
                 description: "Glob pattern to match for determining which changed files should
                     trigger a package publish. Should include a capture group
@@ -65,7 +65,7 @@ on:
                 description: "Nuget feed URLs to publish to, separated by commas."
                 required: true
                 type: string
-                default: ""
+                default: "https://nuget.pkg.github.com/Now-Micro/index.json"
             prerelease-identifier:
                 description: "Pre-release identifier (alpha, beta, preview, rc)"
                 required: false

--- a/.github/workflows/reusable-pre-release.yml
+++ b/.github/workflows/reusable-pre-release.yml
@@ -45,7 +45,7 @@ on:
                 description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
                 required: false
                 type: string
-                default: "github"
+                default: ""
             nuget-pattern-to-match:
                 description: "Glob pattern to match for determining which changed files should
                     trigger a package publish. Should include a capture group

--- a/.github/workflows/reusable-pre-release.yml
+++ b/.github/workflows/reusable-pre-release.yml
@@ -41,6 +41,11 @@ on:
                 required: false
                 type: string
                 default: "nupkgs"
+            nuget-names:
+                description: "NuGet source names used with the configured feed URLs. Should be a comma-separated list matching nuget-urls."
+                required: false
+                type: string
+                default: "github"
             nuget-pattern-to-match:
                 description: "Glob pattern to match for determining which changed files should
                     trigger a package publish. Should include a capture group
@@ -155,6 +160,7 @@ jobs:
                   dotnet-version: ${{ inputs['dotnet-version'] }}
                   directory: ${{ inputs['directory'] }}
                   nuget-package-dir: ${{ inputs['nuget-package-dir'] }}
+                  nuget-names: ${{ inputs['nuget-names'] }}
                   nuget-pattern-to-match: ${{ inputs['nuget-pattern-to-match'] }}
                   nuget-project-regex: ${{ inputs['nuget-project-regex'] }}
                   nuget-urls: ${{ inputs['nuget-urls'] }}
@@ -188,6 +194,7 @@ jobs:
                   directory: ${{ matrix.directory }}
                   dotnet-version: ${{ inputs['dotnet-version'] }}
                   nuget-package-dir: ${{ inputs['nuget-package-dir'] }}
+                  nuget-names: ${{ inputs['nuget-names'] }}
                   nuget-pattern-to-match: ${{ inputs['nuget-pattern-to-match'] }}
                   nuget-project-regex: ${{ inputs['nuget-project-regex'] }}
                   nuget-urls: ${{ inputs['nuget-urls'] }}


### PR DESCRIPTION
This pull request introduces support for specifying custom NuGet source names in both the NuGet publish and pre-release workflows. The main change is the addition of a new `nuget-names` input parameter, allowing users to provide a comma-separated list of NuGet source names that match the configured feed URLs. This makes the workflows more flexible and configurable for different publishing scenarios.

**Workflow input enhancements:**

* Added a new `nuget-names` input parameter (with description and default value) to `.github/workflows/nuget-publish.yml` and `.github/workflows/reusable-pre-release.yml`, enabling users to specify NuGet source names alongside feed URLs. [[1]](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R24-R27) [[2]](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bR44-R48)

* Propagated the new `nuget-names` input through job definitions in both workflow files so that the value can be used in downstream actions. [[1]](diffhunk://#diff-7529579b6fe86f3ab929d1d7c5ea2597814bdb7f475b8bacc7be8c1da2fc43d4R87) [[2]](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bR163) [[3]](diffhunk://#diff-1655054adcc0686a47584f973cd62dd2f9ad136c5efaed5bc013c792132ff10bR197)

**Reusable action improvements:**

* Updated `.github/actions/nuget-publish-workflow/action.yml` and `.github/actions/reusable-pre-release-workflow/action.yml` to accept the `nuget-names` input, including documentation and default values. [[1]](diffhunk://#diff-416b2b6fdbc3f289667027e8d4de72e3788cb033a9cddc29be512cd4345c0d6aR29-R32) [[2]](diffhunk://#diff-0804f83ecbdbf810ad4123c03c3b99a123e7251a9e24fcafee20c34b2c7bdb23R25-R28)

* Modified the `runs` section of both action files to use the `nuget-names` input instead of a hardcoded value, ensuring that custom source names are passed through to the publishing steps. [[1]](diffhunk://#diff-416b2b6fdbc3f289667027e8d4de72e3788cb033a9cddc29be512cd4345c0d6aL175-R179) [[2]](diffhunk://#diff-0804f83ecbdbf810ad4123c03c3b99a123e7251a9e24fcafee20c34b2c7bdb23L133-R137)