### PR TITLE
chore(CODEOWNERS): update to a team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Beschuetzer
+* @Now-Micro/admins-workflows


### PR DESCRIPTION
This pull request makes a small update to the `CODEOWNERS` file, changing the ownership of all files from `@Beschuetzer` to `@Now-Micro/admins-workflows`.