### PR TITLE
feat: add npm publish reusable workflow(GHS-1.0.19)

### DIFF
--- a/.github/actions/demo-npm-publish/action.yml
+++ b/.github/actions/demo-npm-publish/action.yml
@@ -2,6 +2,16 @@ name: Demo - npm Publish
 description: Demonstrates the reusable npm publish workflow by running key npm steps against the demo npm package.
 author: Trafera
 
+inputs:
+  delete-published-package:
+    description: "When true, deletes the published demo package version from GitHub Packages after the run."
+    required: false
+    default: "false"
+  token-github-packages:
+    description: "PAT with write:packages permission. Required for the real publish and delete steps."
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -61,6 +71,77 @@ runs:
         actual: ${{ steps.npm-publish-bad-dir.outcome }}
         test-name: "npm publish with missing package directory -> failure"
         summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Generate unique demo version
+      id: version
+      shell: bash
+      run: |
+          version="0.0.0-ci.${{ github.run_id }}.${{ github.run_attempt }}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "📦 Generated demo version: $version"
+
+    - name: Stamp version into package.json
+      shell: bash
+      working-directory: src/demo/npm
+      run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+
+    - name: Publish demo package to GitHub Packages
+      id: npm-publish-real
+      uses: ./.github/actions/npm-publish-workflow
+      with:
+        access: "restricted"
+        ci-debug-mode: "true"
+        dry-run: "false"
+        node-version: "22.x"
+        package-directory: "src/demo/npm"
+        registry-url: "https://npm.pkg.github.com"
+        scope: "@now-micro"
+        tag: "latest"
+        test-script: "test"
+        token-github-packages: ${{ inputs['token-github-packages'] }}
+
+    - name: Delete published demo package version
+      if: ${{ always() && inputs['delete-published-package'] == 'true' && steps.npm-publish-real.outcome == 'success' }}
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ inputs['token-github-packages'] }}
+        script: |
+          const packageName = 'demo-npm';
+          const versionNumber = '${{ steps.version.outputs.version }}';
+          const org = context.repo.owner;
+
+          core.info(`🔍 Looking for npm package '${packageName}' version '${versionNumber}' in org '${org}'`);
+
+          let versions;
+          try {
+            const resp = await github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg({
+              org,
+              package_type: 'npm',
+              package_name: packageName,
+            });
+            versions = resp.data;
+          } catch (err) {
+            core.warning(`Could not list package versions: ${err.message}`);
+            return;
+          }
+
+          const match = versions.find(v => v.name === versionNumber);
+          if (!match) {
+            core.info(`ℹ️ Version '${versionNumber}' not found in package '${packageName}' — nothing to delete.`);
+            return;
+          }
+
+          try {
+            await github.rest.packages.deletePackageVersionForOrg({
+              org,
+              package_type: 'npm',
+              package_name: packageName,
+              package_version_id: match.id,
+            });
+            core.info(`✅ Deleted npm package version: @now-micro/${packageName}@${versionNumber}`);
+          } catch (err) {
+            core.warning(`Failed to delete package version: ${err.message}`);
+          }
 
     - name: Summary
       if: always()

--- a/.github/actions/demo-npm-publish/action.yml
+++ b/.github/actions/demo-npm-publish/action.yml
@@ -45,6 +45,7 @@ runs:
         scope: "@now-micro"
         tag: "latest"
         test-script: "test"
+        token-github-packages: ${{ inputs['token-github-packages'] }}
 
     - name: Assert dry-run publish with tests succeeded
       uses: ./src/testing/assert
@@ -66,6 +67,7 @@ runs:
         package-directory: "src/demo/npm/__does_not_exist__"
         registry-url: "https://npm.pkg.github.com"
         scope: "@now-micro"
+        token-github-packages: ${{ inputs['token-github-packages'] }}
 
     - name: Assert invalid directory caused failure
       uses: ./src/testing/assert

--- a/.github/actions/demo-npm-publish/action.yml
+++ b/.github/actions/demo-npm-publish/action.yml
@@ -91,6 +91,13 @@ runs:
       working-directory: src/demo/npm
       run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
 
+    - name: Stamp version into changelog
+      shell: bash
+      working-directory: src/demo/npm
+      run: |
+        version="${{ steps.version.outputs.version }}"
+        sed -i "s/^## \[1\.0\.0\]$/## [${version}]/" CHANGELOG.md
+
     - name: Publish demo package to GitHub Packages
       id: npm-publish-real
       uses: ./.github/actions/npm-publish-workflow

--- a/.github/actions/demo-npm-publish/action.yml
+++ b/.github/actions/demo-npm-publish/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: "When true, deletes the published demo package version from GitHub Packages after the run."
     required: false
     default: "false"
+  github-token:
+    description: "GitHub token (GITHUB_TOKEN) used to create and delete the GitHub release."
+    required: false
+    default: ""
   token-github-packages:
     description: "PAT with write:packages permission. Required for the real publish and delete steps."
     required: false
@@ -96,6 +100,7 @@ runs:
         package-directory: "src/demo/npm"
         registry-url: "https://npm.pkg.github.com"
         scope: "@now-micro"
+        github-token: ${{ inputs['github-token'] }}
         tag: "latest"
         test-script: "test"
         token-github-packages: ${{ inputs['token-github-packages'] }}
@@ -141,6 +146,39 @@ runs:
             core.info(`✅ Deleted npm package version: @now-micro/${packageName}@${versionNumber}`);
           } catch (err) {
             core.warning(`Failed to delete package version: ${err.message}`);
+          }
+
+    - name: Delete GitHub release
+      if: ${{ always() && inputs['delete-published-package'] == 'true' && inputs['github-token'] != '' && steps.npm-publish-real.outputs.tag-name != '' }}
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ inputs['github-token'] }}
+        script: |
+          const tag = '${{ steps.npm-publish-real.outputs.tag-name }}';
+          const { owner, repo } = context.repo;
+
+          core.info(`🔍 Looking for GitHub release with tag '${tag}'`);
+          try {
+            const { data: release } = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
+            await github.rest.repos.deleteRelease({ owner, repo, release_id: release.id });
+            core.info(`✅ Deleted GitHub release for tag '${tag}'`);
+          } catch (e) {
+            if (e.status === 404) {
+              core.info(`ℹ️ No GitHub release found for tag '${tag}' — nothing to delete.`);
+            } else {
+              throw e;
+            }
+          }
+
+          try {
+            await github.rest.git.deleteRef({ owner, repo, ref: `tags/${tag}` });
+            core.info(`✅ Deleted git tag '${tag}'`);
+          } catch (e) {
+            if (e.status === 404 || e.status === 422) {
+              core.info(`ℹ️ Git tag '${tag}' not found — nothing to delete.`);
+            } else {
+              throw e;
+            }
           }
 
     - name: Summary

--- a/.github/actions/demo-npm-publish/action.yml
+++ b/.github/actions/demo-npm-publish/action.yml
@@ -1,0 +1,86 @@
+name: Demo - npm Publish
+description: Demonstrates the reusable npm publish workflow by running key npm steps against the demo npm package.
+author: Trafera
+
+runs:
+  using: composite
+  steps:
+    - name: Title - npm Publish Demo
+      uses: ./.github/actions/output-demo-title
+      with:
+        title: npm Publish Demo
+        path: ./.github/actions/demo-npm-publish
+
+    - name: Setup summary file
+      shell: bash
+      run: |
+        echo "SUMMARY_FILE=$GITHUB_WORKSPACE/demo-npm-publish-summary.txt" >> $GITHUB_ENV
+        : > "$GITHUB_WORKSPACE/demo-npm-publish-summary.txt"
+
+    - name: Setup Node.js for GitHub Packages
+      uses: actions/setup-node@v4
+      with:
+        node-version: "22.x"
+        registry-url: "https://npm.pkg.github.com"
+        scope: "@now-micro"
+
+    - name: Install dependencies
+      id: npm-ci
+      continue-on-error: true
+      shell: bash
+      working-directory: src/demo/npm
+      run: npm ci
+
+    - name: Assert npm ci succeeded
+      uses: ./src/testing/assert
+      with:
+        expected: success
+        mode: exact
+        actual: ${{ steps.npm-ci.outcome }}
+        test-name: "npm ci in demo package -> success"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Pack demo package (validates package.json without auth)
+      id: npm-pack
+      continue-on-error: true
+      shell: bash
+      working-directory: src/demo/npm
+      run: npm pack --dry-run
+
+    - name: Assert npm pack succeeded
+      uses: ./src/testing/assert
+      with:
+        expected: success
+        mode: exact
+        actual: ${{ steps.npm-pack.outcome }}
+        test-name: "npm pack --dry-run in demo package -> success"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Run npm ci in directory without package.json (expected failure)
+      id: npm-ci-missing
+      continue-on-error: true
+      shell: bash
+      run: |
+        tmpdir=$(mktemp -d)
+        cd "$tmpdir"
+        npm ci
+
+    - name: Assert npm ci without package.json failed
+      uses: ./src/testing/assert
+      with:
+        expected: failure
+        mode: exact
+        actual: ${{ steps.npm-ci-missing.outcome }}
+        test-name: "npm ci in directory without package.json -> failure"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Summary
+      if: always()
+      shell: bash
+      run: |
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "## npm Publish Demo Results" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        if [ -f "$SUMMARY_FILE" ]; then
+          cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/.github/actions/demo-npm-publish/action.yml
+++ b/.github/actions/demo-npm-publish/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ""
   token-github-packages:
-    description: "PAT with write:packages permission. Required for the real publish and delete steps."
+    description: "PAT with write:packages and delete:packages permissions. Required for the real publish and delete steps."
     required: false
     default: ""
 

--- a/.github/actions/demo-npm-publish/action.yml
+++ b/.github/actions/demo-npm-publish/action.yml
@@ -17,61 +17,49 @@ runs:
         echo "SUMMARY_FILE=$GITHUB_WORKSPACE/demo-npm-publish-summary.txt" >> $GITHUB_ENV
         : > "$GITHUB_WORKSPACE/demo-npm-publish-summary.txt"
 
-    - name: Setup Node.js for GitHub Packages
-      uses: actions/setup-node@v4
+    - name: Run npm publish workflow (dry run with tests)
+      id: npm-publish-success
+      continue-on-error: true
+      uses: ./.github/actions/npm-publish-workflow
       with:
+        access: "restricted"
+        ci-debug-mode: "true"
+        dry-run: "true"
         node-version: "22.x"
+        package-directory: "src/demo/npm"
+        registry-url: "https://npm.pkg.github.com"
+        scope: "@now-micro"
+        tag: "latest"
+        test-script: "test"
+
+    - name: Assert dry-run publish with tests succeeded
+      uses: ./src/testing/assert
+      with:
+        expected: success
+        mode: exact
+        actual: ${{ steps.npm-publish-success.outcome }}
+        test-name: "npm publish dry-run with tests -> success"
+        summary-file: ${{ env.SUMMARY_FILE }}
+
+    - name: Run npm publish workflow with invalid package directory (expected failure)
+      id: npm-publish-bad-dir
+      continue-on-error: true
+      uses: ./.github/actions/npm-publish-workflow
+      with:
+        access: "restricted"
+        dry-run: "true"
+        node-version: "22.x"
+        package-directory: "src/demo/npm/__does_not_exist__"
         registry-url: "https://npm.pkg.github.com"
         scope: "@now-micro"
 
-    - name: Install dependencies
-      id: npm-ci
-      continue-on-error: true
-      shell: bash
-      working-directory: src/demo/npm
-      run: npm ci
-
-    - name: Assert npm ci succeeded
-      uses: ./src/testing/assert
-      with:
-        expected: success
-        mode: exact
-        actual: ${{ steps.npm-ci.outcome }}
-        test-name: "npm ci in demo package -> success"
-        summary-file: ${{ env.SUMMARY_FILE }}
-
-    - name: Pack demo package (validates package.json without auth)
-      id: npm-pack
-      continue-on-error: true
-      shell: bash
-      working-directory: src/demo/npm
-      run: npm pack --dry-run
-
-    - name: Assert npm pack succeeded
-      uses: ./src/testing/assert
-      with:
-        expected: success
-        mode: exact
-        actual: ${{ steps.npm-pack.outcome }}
-        test-name: "npm pack --dry-run in demo package -> success"
-        summary-file: ${{ env.SUMMARY_FILE }}
-
-    - name: Run npm ci in directory without package.json (expected failure)
-      id: npm-ci-missing
-      continue-on-error: true
-      shell: bash
-      run: |
-        tmpdir=$(mktemp -d)
-        cd "$tmpdir"
-        npm ci
-
-    - name: Assert npm ci without package.json failed
+    - name: Assert invalid directory caused failure
       uses: ./src/testing/assert
       with:
         expected: failure
         mode: exact
-        actual: ${{ steps.npm-ci-missing.outcome }}
-        test-name: "npm ci in directory without package.json -> failure"
+        actual: ${{ steps.npm-publish-bad-dir.outcome }}
+        test-name: "npm publish with missing package directory -> failure"
         summary-file: ${{ env.SUMMARY_FILE }}
 
     - name: Summary

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -1,5 +1,5 @@
 name: npm Publish Workflow
-description: Shared composite action for the reusable-npm-publish workflow. Runs a lockfile-aware npm install, optional tests, and npm publish.
+description: Shared composite action for the reusable-npm-publish workflow. Validates the changelog, runs a lockfile-aware npm install, optional tests, and npm publish.
 
 inputs:
   access:
@@ -91,8 +91,6 @@ runs:
         node-version: ${{ inputs['node-version'] }}
         registry-url: ${{ inputs['registry-url'] }}
         scope: ${{ inputs.scope }}
-        install-dependencies: 'true'
-        install-dependencies-directory: ${{ inputs['package-directory'] }}
         token-github-packages: ${{ inputs['token-github-packages'] }}
 
     - name: Read package info
@@ -107,13 +105,45 @@ runs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "library-name=$library_name" >> "$GITHUB_OUTPUT"
 
+    - name: Extract Changelog
+      id: extract-changelog
+      uses: Now-Micro/actions/extract-changelog@v1
+      with:
+        library-directory: ${{ inputs['package-directory'] }}
+        library-name: ${{ steps.pkg-info.outputs.library-name }}
+        changelog-content-path: ${{ inputs['package-directory'] }}/CHANGELOG-EXTRACTED.md
+        create-artifact: "false"
+        version: ${{ steps.pkg-info.outputs.version }}
+
+    - name: Validate changelog exists
+      shell: bash
+      run: |
+          if [ -z "${{ steps.extract-changelog.outputs.changelog-content }}" ]; then
+            echo "No changelog content found for version ${{ steps.pkg-info.outputs.version }}. Ensure a CHANGELOG.md exists and contains an entry for this version."
+            exit 1
+          fi
+
+    - name: Install dependencies
+      uses: ./setup-node
+      with:
+        node-version: ${{ inputs['node-version'] }}
+        registry-url: ${{ inputs['registry-url'] }}
+        scope: ${{ inputs.scope }}
+        install-dependencies: 'true'
+        install-dependencies-directory: ${{ inputs['package-directory'] }}
+        install-dependencies-mode: 'auto'
+        token-github-packages: ${{ inputs['token-github-packages'] }}
+
     - name: Install test dependencies
       if: ${{ inputs['test-script'] != '' && inputs['test-directory'] != '' && inputs['test-directory'] != inputs['package-directory'] }}
       uses: ./setup-node
       with:
         node-version: ${{ inputs['node-version'] }}
+        registry-url: ${{ inputs['registry-url'] }}
+        scope: ${{ inputs.scope }}
         install-dependencies: 'true'
         install-dependencies-directory: ${{ inputs['test-directory'] }}
+        install-dependencies-mode: 'auto'
         token-github-packages: ${{ inputs['token-github-packages'] }}
 
     - name: Run tests

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -131,7 +131,6 @@ runs:
         scope: ${{ inputs.scope }}
         install-dependencies: 'true'
         install-dependencies-directory: ${{ inputs['package-directory'] }}
-        install-dependencies-mode: 'auto'
         token-github-packages: ${{ inputs['token-github-packages'] }}
 
     - name: Install test dependencies
@@ -143,7 +142,6 @@ runs:
         scope: ${{ inputs.scope }}
         install-dependencies: 'true'
         install-dependencies-directory: ${{ inputs['test-directory'] }}
-        install-dependencies-mode: 'auto'
         token-github-packages: ${{ inputs['token-github-packages'] }}
 
     - name: Run tests

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -45,6 +45,21 @@ inputs:
     description: "Token used to authenticate to the npm registry. Passed as NODE_AUTH_TOKEN."
     required: false
     default: ""
+  github-token:
+    description: "GitHub token (GITHUB_TOKEN) used to create a GitHub release after publishing. When empty, the release step is skipped."
+    required: false
+    default: ""
+
+outputs:
+  release-url:
+    description: "URL of the created GitHub release. Empty when dry-run is true or github-token is not provided."
+    value: ${{ steps.create-release.outputs.release-url }}
+  release-name:
+    description: "Name of the created GitHub release."
+    value: ${{ steps.create-release.outputs.release-name }}
+  tag-name:
+    description: "Tag name of the created GitHub release."
+    value: ${{ steps.create-release.outputs.tag-name }}
 
 runs:
   using: composite
@@ -60,6 +75,18 @@ runs:
       working-directory: ${{ inputs['package-directory'] }}
       shell: bash
       run: npm ci
+
+    - name: Read package info
+      id: pkg-info
+      shell: bash
+      working-directory: ${{ inputs['package-directory'] }}
+      run: |
+          name=$(node -e "process.stdout.write(require('./package.json').name)")
+          version=$(node -e "process.stdout.write(require('./package.json').version)")
+          library_name="${name##*/}"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "library-name=$library_name" >> "$GITHUB_OUTPUT"
 
     - name: Install test dependencies
       if: ${{ inputs['test-script'] != '' && inputs['test-directory'] != '' && inputs['test-directory'] != inputs['package-directory'] }}
@@ -107,3 +134,13 @@ runs:
 
           echo "📦 Publishing npm package from ${{ inputs['package-directory'] }}..."
           npm publish $ARGS
+
+    - name: Create GitHub Release
+      id: create-release
+      if: ${{ inputs['dry-run'] != 'true' && inputs['github-token'] != '' }}
+      uses: Now-Micro/actions/github/release@v1
+      with:
+          github-token: ${{ inputs['github-token'] }}
+          library-name: ${{ steps.pkg-info.outputs.library-name }}
+          release-version: ${{ steps.pkg-info.outputs.version }}
+          skip-download: "true"

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -1,5 +1,5 @@
 name: npm Publish Workflow
-description: Shared composite action for the reusable-npm-publish workflow. Validates the changelog, runs a lockfile-aware npm install, optional tests, and npm publish.
+description: Shared composite action for the reusable-npm-publish workflow. Validates the changelog, runs a lockfile-aware npm install, optional tests, npm publish, and optionally creates a GitHub Release when a GitHub token is provided.
 
 inputs:
   access:
@@ -178,14 +178,14 @@ runs:
             echo "🔍 test-directory: ${{ inputs['test-directory'] }}"
           fi
 
-          ARGS="--access $access --tag $tag"
+          args=(--access "$access" --tag "$tag")
           if [[ "$dry_run" == "true" ]]; then
-            ARGS="$ARGS --dry-run"
+            args+=(--dry-run)
             echo "ℹ️ Dry run mode enabled; package will not be published."
           fi
 
           echo "📦 Publishing npm package from ${{ inputs['package-directory'] }}..."
-          npm publish $ARGS
+          npm publish "${args[@]}"
 
     - name: Create GitHub Release
       id: create-release

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -1,5 +1,5 @@
 name: npm Publish Workflow
-description: Shared composite action for the reusable-npm-publish workflow. Runs npm ci, optional tests, and npm publish.
+description: Shared composite action for the reusable-npm-publish workflow. Runs a lockfile-aware npm install, optional tests, and npm publish.
 
 inputs:
   access:
@@ -74,7 +74,14 @@ runs:
     - name: Install dependencies
       working-directory: ${{ inputs['package-directory'] }}
       shell: bash
-      run: npm ci
+      run: |
+          if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
+            echo "📦 Installing package dependencies with npm ci"
+            npm ci
+          else
+            echo "⚠️ No lockfile found; installing package dependencies with npm install --no-package-lock"
+            npm install --no-package-lock --no-audit --no-fund
+          fi
 
     - name: Read package info
       id: pkg-info
@@ -92,7 +99,14 @@ runs:
       if: ${{ inputs['test-script'] != '' && inputs['test-directory'] != '' && inputs['test-directory'] != inputs['package-directory'] }}
       working-directory: ${{ inputs['test-directory'] }}
       shell: bash
-      run: npm ci
+      run: |
+          if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
+            echo "🧪 Installing test dependencies with npm ci"
+            npm ci
+          else
+            echo "⚠️ No lockfile found; installing test dependencies with npm install --no-package-lock"
+            npm install --no-package-lock --no-audit --no-fund
+          fi
 
     - name: Run tests
       if: ${{ inputs['test-script'] != '' }}

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -42,7 +42,7 @@ inputs:
     required: false
     default: ""
   token-github-packages:
-    description: "Token used to authenticate to the npm registry. Passed as NODE_AUTH_TOKEN."
+    description: "Token used to authenticate to the npm registry. Passed as NODE_AUTH_TOKEN. Required for real publishes and GitHub Packages installs."
     required: false
     default: ""
   github-token:
@@ -64,6 +64,27 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate publish auth
+      shell: bash
+      run: |
+          dry_run="${{ inputs['dry-run'] }}"
+          registry_url="${{ inputs['registry-url'] }}"
+          token="${{ inputs['token-github-packages'] }}"
+
+          requires_token="false"
+          if [[ "$dry_run" != "true" ]]; then
+            requires_token="true"
+          fi
+
+          if [[ "$registry_url" == *"npm.pkg.github.com"* ]]; then
+            requires_token="true"
+          fi
+
+          if [[ "$requires_token" == "true" && -z "$token" ]]; then
+            echo "❌ token-github-packages is required when dry-run is false or when using GitHub Packages."
+            exit 1
+          fi
+
     - name: Setup Node.js
       uses: ./setup-node
       with:

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -72,6 +72,7 @@ runs:
         scope: ${{ inputs.scope }}
         install-dependencies: 'true'
         install-dependencies-directory: ${{ inputs['package-directory'] }}
+        token-github-packages: ${{ inputs['token-github-packages'] }}
 
     - name: Read package info
       id: pkg-info
@@ -92,6 +93,7 @@ runs:
         node-version: ${{ inputs['node-version'] }}
         install-dependencies: 'true'
         install-dependencies-directory: ${{ inputs['test-directory'] }}
+        token-github-packages: ${{ inputs['token-github-packages'] }}
 
     - name: Run tests
       if: ${{ inputs['test-script'] != '' }}

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -1,0 +1,109 @@
+name: npm Publish Workflow
+description: Shared composite action for the reusable-npm-publish workflow. Runs npm ci, optional tests, and npm publish.
+
+inputs:
+  access:
+    description: "Package access level ('public' or 'restricted')."
+    required: false
+    default: "restricted"
+  ci-debug-mode:
+    description: "Debug mode for additional logging during the publish steps."
+    required: false
+    default: "false"
+  dry-run:
+    description: "When true, runs npm publish with --dry-run. No package is actually published."
+    required: false
+    default: "false"
+  node-version:
+    description: "Node.js version to use when installing and publishing."
+    required: false
+    default: "22.x"
+  package-directory:
+    description: "Directory containing the package.json to publish. Relative to the repository root."
+    required: true
+  registry-url:
+    description: "npm registry URL to publish to. Defaults to the GitHub Packages npm registry."
+    required: false
+    default: "https://npm.pkg.github.com"
+  scope:
+    description: "npm package scope (e.g. '@my-org'). Must match the scope prefix in the package.json name field."
+    required: false
+    default: ""
+  tag:
+    description: "npm distribution tag applied to the published version (e.g. 'latest', 'next', 'beta')."
+    required: false
+    default: "latest"
+  test-directory:
+    description: "Directory containing the package.json whose test script should be run. Defaults to package-directory when empty."
+    required: false
+    default: ""
+  test-script:
+    description: "npm script name to run before publishing (e.g. 'test', 'test:ci'). When empty, the test step is skipped."
+    required: false
+    default: ""
+  token-github-packages:
+    description: "Token used to authenticate to the npm registry. Passed as NODE_AUTH_TOKEN."
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs['node-version'] }}
+        registry-url: ${{ inputs['registry-url'] }}
+        scope: ${{ inputs.scope }}
+
+    - name: Install dependencies
+      working-directory: ${{ inputs['package-directory'] }}
+      shell: bash
+      run: npm ci
+
+    - name: Install test dependencies
+      if: ${{ inputs['test-script'] != '' && inputs['test-directory'] != '' && inputs['test-directory'] != inputs['package-directory'] }}
+      working-directory: ${{ inputs['test-directory'] }}
+      shell: bash
+      run: npm ci
+
+    - name: Run tests
+      if: ${{ inputs['test-script'] != '' }}
+      working-directory: ${{ inputs['test-directory'] != '' && inputs['test-directory'] || inputs['package-directory'] }}
+      shell: bash
+      run: |
+          script="${{ inputs['test-script'] }}"
+          echo "🧪 Running npm run $script..."
+          npm run "$script"
+
+    - name: Publish npm package
+      working-directory: ${{ inputs['package-directory'] }}
+      shell: bash
+      env:
+          NODE_AUTH_TOKEN: ${{ inputs['token-github-packages'] }}
+      run: |
+          debug="${{ inputs['ci-debug-mode'] }}"
+          dry_run="${{ inputs['dry-run'] }}"
+          tag="${{ inputs.tag }}"
+          access="${{ inputs.access }}"
+
+          if [[ "$debug" == "true" ]]; then
+            echo "🔍 Debug mode is ON"
+            echo "🔍 package-directory: ${{ inputs['package-directory'] }}"
+            echo "🔍 registry-url: ${{ inputs['registry-url'] }}"
+            echo "🔍 scope: ${{ inputs.scope }}"
+            echo "🔍 tag: $tag"
+            echo "🔍 access: $access"
+            echo "🔍 dry-run: $dry_run"
+            echo "🔍 test-script: ${{ inputs['test-script'] }}"
+            echo "🔍 test-directory: ${{ inputs['test-directory'] }}"
+          fi
+
+          ARGS="--access $access --tag $tag"
+          if [[ "$dry_run" == "true" ]]; then
+            ARGS="$ARGS --dry-run"
+            echo "ℹ️ Dry run mode enabled; package will not be published."
+          fi
+
+          echo "📦 Publishing npm package from ${{ inputs['package-directory'] }}..."
+          npm publish $ARGS

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -65,23 +65,13 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: ./setup-node
       with:
         node-version: ${{ inputs['node-version'] }}
         registry-url: ${{ inputs['registry-url'] }}
         scope: ${{ inputs.scope }}
-
-    - name: Install dependencies
-      working-directory: ${{ inputs['package-directory'] }}
-      shell: bash
-      run: |
-          if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
-            echo "📦 Installing package dependencies with npm ci"
-            npm ci
-          else
-            echo "⚠️ No lockfile found; installing package dependencies with npm install --no-package-lock"
-            npm install --no-package-lock --no-audit --no-fund
-          fi
+        install-dependencies: 'true'
+        install-dependencies-directory: ${{ inputs['package-directory'] }}
 
     - name: Read package info
       id: pkg-info
@@ -97,16 +87,11 @@ runs:
 
     - name: Install test dependencies
       if: ${{ inputs['test-script'] != '' && inputs['test-directory'] != '' && inputs['test-directory'] != inputs['package-directory'] }}
-      working-directory: ${{ inputs['test-directory'] }}
-      shell: bash
-      run: |
-          if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
-            echo "🧪 Installing test dependencies with npm ci"
-            npm ci
-          else
-            echo "⚠️ No lockfile found; installing test dependencies with npm install --no-package-lock"
-            npm install --no-package-lock --no-audit --no-fund
-          fi
+      uses: ./setup-node
+      with:
+        node-version: ${{ inputs['node-version'] }}
+        install-dependencies: 'true'
+        install-dependencies-directory: ${{ inputs['test-directory'] }}
 
     - name: Run tests
       if: ${{ inputs['test-script'] != '' }}

--- a/.github/actions/npm-publish-workflow/action.yml
+++ b/.github/actions/npm-publish-workflow/action.yml
@@ -191,6 +191,7 @@ runs:
       uses: Now-Micro/actions/github/release@v1
       with:
           github-token: ${{ inputs['github-token'] }}
+          changelog-path: ${{ inputs['package-directory'] }}/CHANGELOG.md
           library-name: ${{ steps.pkg-info.outputs.library-name }}
           release-version: ${{ steps.pkg-info.outputs.version }}
           skip-download: "true"

--- a/.github/actions/run-demo-workflows/action.yml
+++ b/.github/actions/run-demo-workflows/action.yml
@@ -99,6 +99,9 @@ runs:
     - name: Demo - get-unique-root-directories
       uses: ./.github/actions/demo-get-unique-root-directories
 
+    - name: Demo - npm publish
+      uses: ./.github/actions/demo-npm-publish
+
     - name: Demo - string-manipulator
       uses: ./.github/actions/demo-string-manipulator
 

--- a/.github/actions/run-demo-workflows/action.yml
+++ b/.github/actions/run-demo-workflows/action.yml
@@ -18,6 +18,13 @@ runs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+      
+    - name: Demo - npm publish
+      uses: ./.github/actions/demo-npm-publish
+      with:
+        delete-published-package: "true"
+        github-token: ${{ inputs.github-release-token }}
+        token-github-packages: ${{ inputs.github-token }}
 
     - name: Demo - checks-workflow
       uses: ./.github/actions/demo-checks-workflow
@@ -98,13 +105,6 @@ runs:
 
     - name: Demo - get-unique-root-directories
       uses: ./.github/actions/demo-get-unique-root-directories
-
-    - name: Demo - npm publish
-      uses: ./.github/actions/demo-npm-publish
-      with:
-        delete-published-package: "true"
-        github-token: ${{ inputs.github-release-token }}
-        token-github-packages: ${{ inputs.github-token }}
 
     - name: Demo - string-manipulator
       uses: ./.github/actions/demo-string-manipulator

--- a/.github/actions/run-demo-workflows/action.yml
+++ b/.github/actions/run-demo-workflows/action.yml
@@ -101,6 +101,10 @@ runs:
 
     - name: Demo - npm publish
       uses: ./.github/actions/demo-npm-publish
+      with:
+        delete-published-package: "true"
+        github-token: ${{ inputs.github-release-token }}
+        token-github-packages: ${{ inputs.github-token }}
 
     - name: Demo - string-manipulator
       uses: ./.github/actions/demo-string-manipulator

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -369,8 +369,9 @@ Installs dependencies and publishes a scoped npm package to GitHub Packages (or 
 1. Validates that the required secret and the `access` input are present and valid.
 2. Checks out the repository.
 3. Configures Node.js and the `.npmrc` for the target registry and scope.
-4. Runs `npm ci` when a lockfile exists in the specified `package-directory`, otherwise falls back to `npm install --no-package-lock`.
-5. Runs `npm publish` with the configured access level and distribution tag.
+4. Extracts and validates the changelog entry for the package version before any dependency installation.
+5. Runs `npm ci` when a lockfile exists in the specified `package-directory`, otherwise falls back to `npm install --no-package-lock`.
+6. Runs `npm publish` with the configured access level and distribution tag.
 
 #### npm Publish Inputs
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -362,7 +362,7 @@ For example, if the `.csproj` contains `<VersionPrefix>1.2.3</VersionPrefix>` an
 
 ### npm Publish Workflow
 
-Installs dependencies and publishes a scoped npm package to GitHub Packages (or another npm registry). Intended to be called from a workflow that runs on `main` after a version has been set in `package.json`.
+Installs dependencies, publishes a scoped npm package to GitHub Packages (or another npm registry), and creates a GitHub Release for real publishes when a GitHub token is provided. Intended to be called from a workflow that runs on `main` after a version has been set in `package.json`.
 
 #### npm Publish What it does
 
@@ -372,6 +372,7 @@ Installs dependencies and publishes a scoped npm package to GitHub Packages (or 
 4. Extracts and validates the changelog entry for the package version before any dependency installation.
 5. Runs `npm ci` when a lockfile exists in the specified `package-directory`, otherwise falls back to `npm install --no-package-lock`.
 6. Runs `npm publish` with the configured access level and distribution tag.
+7. Creates a GitHub Release using the forwarded `GITHUB_TOKEN` unless `dry-run` is `true`.
 
 #### npm Publish Inputs
 
@@ -399,6 +400,7 @@ Installs dependencies and publishes a scoped npm package to GitHub Packages (or 
 - The token is passed to npm via the `NODE_AUTH_TOKEN` environment variable, not embedded in `.npmrc`. It is never echoed to logs.
 - The job only runs when the workflow is triggered from `main` (`github.ref_name == 'main'`), preventing accidental publishes from feature branches.
 - Use a PAT scoped to `write:packages` only — do not use a token with broader permissions.
+- The reusable workflow runs with `contents: write` so the composite action can create a GitHub Release on real publishes. Dry runs skip release creation.
 - The `package.json` version must be bumped before calling this workflow. Do not republish the same version.
 
 #### npm Publish Usage

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -30,6 +30,12 @@ This directory contains GitHub Actions **reusable workflows** — shared workflo
     - [Usage - auto-detect changed packages on a PR](#pre-release-nuget-usage---auto-detect-changed-packages-on-a-pr)
     - [Usage - publish a specific directory](#pre-release-nuget-usage---publish-a-specific-directory)
     - [Version format](#pre-release-nuget-version-format)
+  - [npm Publish Workflow](#npm-publish-workflow)
+    - [What it does](#npm-publish-what-it-does)
+    - [Inputs](#npm-publish-inputs)
+    - [Secrets](#npm-publish-secrets)
+    - [Security notes](#npm-publish-security-notes)
+    - [Usage](#npm-publish-usage)
 
 ---
 
@@ -350,4 +356,59 @@ For example, if the `.csproj` contains `<VersionPrefix>1.2.3</VersionPrefix>` an
 
 ```
 1.2.4-alpha-202506011430
+```
+
+---
+
+### npm Publish Workflow
+
+Installs dependencies and publishes a scoped npm package to GitHub Packages (or another npm registry). Intended to be called from a workflow that runs on `main` after a version has been set in `package.json`.
+
+#### npm Publish What it does
+
+1. Validates that the required secret and the `access` input are present and valid.
+2. Checks out the repository.
+3. Configures Node.js and the `.npmrc` for the target registry and scope.
+4. Runs `npm ci` in the specified `package-directory`.
+5. Runs `npm publish` with the configured access level and distribution tag.
+
+#### npm Publish Inputs
+
+| Name | Required | Default | Description |
+|---|---|---|---|
+| `access` | No | `restricted` | Package access level. Use `public` for public packages or `restricted` for private/org-scoped packages. |
+| `ci-debug-mode` | No | `false` | Enable verbose debug logging during the publish steps. |
+| `dry-run` | No | `false` | When `true`, runs `npm publish --dry-run`. No package is actually published. |
+| `node-version` | No | `22.x` | Node.js version to use when installing and publishing. |
+| `package-directory` | **Yes** | — | Directory containing the `package.json` to publish. Relative to the repository root. |
+| `registry-url` | No | `https://npm.pkg.github.com` | npm registry URL to publish to. |
+| `scope` | No | `""` | npm package scope (e.g. `@my-org`). Must match the scope prefix in the `package.json` name field. Required when publishing to GitHub Packages. |
+| `tag` | No | `latest` | npm distribution tag applied to the published version (e.g. `latest`, `next`, `beta`). |
+
+#### npm Publish Secrets
+
+| Name | Required | Description |
+|---|---|---|
+| `token-github-packages` | Yes | PAT with `write:packages` permission used to authenticate to the npm registry. |
+
+#### npm Publish Security notes
+
+- The token is passed to npm via the `NODE_AUTH_TOKEN` environment variable, not embedded in `.npmrc`. It is never echoed to logs.
+- The job only runs when the workflow is triggered from `main` (`github.ref_name == 'main'`), preventing accidental publishes from feature branches.
+- Use a PAT scoped to `write:packages` only — do not use a token with broader permissions.
+- The `package.json` version must be bumped before calling this workflow. Do not republish the same version.
+
+#### npm Publish Usage
+
+```yaml
+jobs:
+  publish:
+    uses: Now-Micro/actions/.github/workflows/reusable-npm-publish.yml@v1
+    with:
+      package-directory: "src/my-library"
+      scope: "@my-org"
+      access: "restricted"
+      tag: "latest"
+    secrets:
+      token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}
 ```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -369,7 +369,7 @@ Installs dependencies and publishes a scoped npm package to GitHub Packages (or 
 1. Validates that the required secret and the `access` input are present and valid.
 2. Checks out the repository.
 3. Configures Node.js and the `.npmrc` for the target registry and scope.
-4. Runs `npm ci` in the specified `package-directory`.
+4. Runs `npm ci` when a lockfile exists in the specified `package-directory`, otherwise falls back to `npm install --no-package-lock`.
 5. Runs `npm publish` with the configured access level and distribution tag.
 
 #### npm Publish Inputs

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -384,6 +384,8 @@ Installs dependencies and publishes a scoped npm package to GitHub Packages (or 
 | `registry-url` | No | `https://npm.pkg.github.com` | npm registry URL to publish to. |
 | `scope` | No | `""` | npm package scope (e.g. `@my-org`). Must match the scope prefix in the `package.json` name field. Required when publishing to GitHub Packages. |
 | `tag` | No | `latest` | npm distribution tag applied to the published version (e.g. `latest`, `next`, `beta`). |
+| `test-directory` | No | `""` | Directory containing the `package.json` whose test script should be run. Defaults to `package-directory` when `test-script` is set and this is empty. |
+| `test-script` | No | `""` | npm script name to run before publishing (e.g. `test`, `test:ci`). When empty, the test step is skipped. If the script exits non-zero, the workflow stops and nothing is published. |
 
 #### npm Publish Secrets
 

--- a/.github/workflows/demo-npm-publish.yml
+++ b/.github/workflows/demo-npm-publish.yml
@@ -1,0 +1,22 @@
+name: Demo - npm Publish
+
+on:
+    workflow_dispatch:
+        inputs:
+            node-version:
+                description: "Node.js version to use."
+                required: false
+                type: string
+                default: "22.x"
+
+jobs:
+    demo-npm-publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Run npm publish demo
+              uses: ./.github/actions/demo-npm-publish

--- a/.github/workflows/demo-npm-publish.yml
+++ b/.github/workflows/demo-npm-publish.yml
@@ -27,4 +27,5 @@ jobs:
               uses: ./.github/actions/demo-npm-publish
               with:
                   delete-published-package: ${{ inputs['delete-published-package'] }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}

--- a/.github/workflows/demo-npm-publish.yml
+++ b/.github/workflows/demo-npm-publish.yml
@@ -3,6 +3,11 @@ name: Demo - npm Publish
 on:
     workflow_dispatch:
         inputs:
+            delete-published-package:
+                description: "When true, deletes the published demo package version after the run."
+                required: false
+                type: boolean
+                default: true
             node-version:
                 description: "Node.js version to use."
                 required: false
@@ -20,3 +25,6 @@ jobs:
 
             - name: Run npm publish demo
               uses: ./.github/actions/demo-npm-publish
+              with:
+                  delete-published-package: ${{ inputs['delete-published-package'] }}
+                  token-github-packages: ${{ secrets.TOKEN_GITHUB_PACKAGES }}

--- a/.github/workflows/reusable-npm-publish.yml
+++ b/.github/workflows/reusable-npm-publish.yml
@@ -102,6 +102,7 @@ jobs:
                   registry-url: ${{ inputs['registry-url'] }}
                   scope: ${{ inputs.scope }}
                   tag: ${{ inputs.tag }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   test-directory: ${{ inputs['test-directory'] }}
                   test-script: ${{ inputs['test-script'] }}
                   token-github-packages: ${{ secrets['token-github-packages'] }}

--- a/.github/workflows/reusable-npm-publish.yml
+++ b/.github/workflows/reusable-npm-publish.yml
@@ -1,4 +1,4 @@
-name: Reusable - npm Package
+name: Reusable - npm Publish
 
 permissions:
     contents: read
@@ -46,6 +46,16 @@ on:
                 required: false
                 type: string
                 default: "latest"
+            test-directory:
+                description: "Directory containing the package.json whose test script should be run. If empty, defaults to package-directory when test-script is set."
+                required: false
+                type: string
+                default: ""
+            test-script:
+                description: "npm script name to run as the test step (e.g. 'test', 'test:ci'). When empty, the test step is skipped entirely and the workflow proceeds straight to publish."
+                required: false
+                type: string
+                default: ""
         secrets:
             token-github-packages:
                 description: "PAT with write:packages permission used to authenticate to the npm registry."
@@ -93,6 +103,21 @@ jobs:
               shell: bash
               run: npm ci
 
+            - name: Install test dependencies
+              if: ${{ inputs['test-script'] != '' && inputs['test-directory'] != '' && inputs['test-directory'] != inputs['package-directory'] }}
+              working-directory: ${{ inputs['test-directory'] }}
+              shell: bash
+              run: npm ci
+
+            - name: Run tests
+              if: ${{ inputs['test-script'] != '' }}
+              working-directory: ${{ inputs['test-directory'] != '' && inputs['test-directory'] || inputs['package-directory'] }}
+              shell: bash
+              run: |
+                  script="${{ inputs['test-script'] }}"
+                  echo "🧪 Running npm run $script..."
+                  npm run "$script"
+
             - name: Publish npm package
               working-directory: ${{ inputs['package-directory'] }}
               shell: bash
@@ -112,6 +137,8 @@ jobs:
                     echo "🔍 tag: $tag"
                     echo "🔍 access: $access"
                     echo "🔍 dry-run: $dry_run"
+                    echo "🔍 test-script: ${{ inputs['test-script'] }}"
+                    echo "🔍 test-directory: ${{ inputs['test-directory'] }}"
                   fi
 
                   ARGS="--access $access --tag $tag"

--- a/.github/workflows/reusable-npm-publish.yml
+++ b/.github/workflows/reusable-npm-publish.yml
@@ -1,0 +1,124 @@
+name: Reusable - npm Package
+
+permissions:
+    contents: read
+    packages: write
+
+on:
+    workflow_call:
+        inputs:
+            access:
+                description: "Package access level. Use 'public' for public packages or 'restricted' for private/org-scoped packages."
+                required: false
+                type: string
+                default: "restricted"
+            ci-debug-mode:
+                description: "Debug mode for additional logging during the publish steps."
+                required: false
+                type: string
+                default: "false"
+            dry-run:
+                description: "When true, runs npm publish with --dry-run. No package is actually published."
+                required: false
+                type: string
+                default: "false"
+            node-version:
+                description: "Node.js version to use when installing and publishing."
+                required: false
+                type: string
+                default: "22.x"
+            package-directory:
+                description: "Directory containing the package.json to publish. Relative to the repository root."
+                required: true
+                type: string
+            registry-url:
+                description: "npm registry URL to publish to. Defaults to the GitHub Packages npm registry."
+                required: false
+                type: string
+                default: "https://npm.pkg.github.com"
+            scope:
+                description: "npm package scope (e.g. '@my-org'). Must match the scope prefix in the package.json name field. Required when publishing to GitHub Packages."
+                required: false
+                type: string
+                default: ""
+            tag:
+                description: "npm distribution tag applied to the published version (e.g. 'latest', 'next', 'beta')."
+                required: false
+                type: string
+                default: "latest"
+        secrets:
+            token-github-packages:
+                description: "PAT with write:packages permission used to authenticate to the npm registry."
+                required: true
+
+jobs:
+    npm-publish:
+        if: ${{ github.ref_name == 'main' }}
+        runs-on: ubuntu-22.04
+        steps:
+            - name: Validate inputs
+              shell: bash
+              env:
+                  TOKEN_GITHUB_PACKAGES: ${{ secrets['token-github-packages'] }}
+              run: |
+                  valid_access="public restricted"
+                  access="${{ inputs.access }}"
+
+                  if [[ -z "$TOKEN_GITHUB_PACKAGES" ]]; then
+                    echo "❌ Required secret 'token-github-packages' is empty."
+                    exit 1
+                  fi
+
+                  if [[ ! " $valid_access " =~ " $access " ]]; then
+                    echo "❌ Invalid access: '$access'. Must be one of: $valid_access"
+                    exit 1
+                  fi
+
+                  echo "✅ Inputs validated."
+
+            - name: Check out code
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs['node-version'] }}
+                  registry-url: ${{ inputs['registry-url'] }}
+                  scope: ${{ inputs.scope }}
+
+            - name: Install dependencies
+              working-directory: ${{ inputs['package-directory'] }}
+              shell: bash
+              run: npm ci
+
+            - name: Publish npm package
+              working-directory: ${{ inputs['package-directory'] }}
+              shell: bash
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets['token-github-packages'] }}
+              run: |
+                  debug="${{ inputs['ci-debug-mode'] }}"
+                  dry_run="${{ inputs['dry-run'] }}"
+                  tag="${{ inputs.tag }}"
+                  access="${{ inputs.access }}"
+
+                  if [[ "$debug" == "true" ]]; then
+                    echo "🔍 Debug mode is ON"
+                    echo "🔍 package-directory: ${{ inputs['package-directory'] }}"
+                    echo "🔍 registry-url: ${{ inputs['registry-url'] }}"
+                    echo "🔍 scope: ${{ inputs.scope }}"
+                    echo "🔍 tag: $tag"
+                    echo "🔍 access: $access"
+                    echo "🔍 dry-run: $dry_run"
+                  fi
+
+                  ARGS="--access $access --tag $tag"
+                  if [[ "$dry_run" == "true" ]]; then
+                    ARGS="$ARGS --dry-run"
+                    echo "ℹ️ Dry run mode enabled; package will not be published."
+                  fi
+
+                  echo "📦 Publishing npm package from ${{ inputs['package-directory'] }}..."
+                  npm publish $ARGS

--- a/.github/workflows/reusable-npm-publish.yml
+++ b/.github/workflows/reusable-npm-publish.yml
@@ -1,7 +1,7 @@
 name: Reusable - npm Publish
 
 permissions:
-    contents: read
+    contents: write
     packages: write
 
 on:

--- a/.github/workflows/reusable-npm-publish.yml
+++ b/.github/workflows/reusable-npm-publish.yml
@@ -91,61 +91,17 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
+            - name: Run npm publish workflow
+              uses: Now-Micro/actions/.github/actions/npm-publish-workflow@v1
               with:
+                  access: ${{ inputs.access }}
+                  ci-debug-mode: ${{ inputs['ci-debug-mode'] }}
+                  dry-run: ${{ inputs['dry-run'] }}
                   node-version: ${{ inputs['node-version'] }}
+                  package-directory: ${{ inputs['package-directory'] }}
                   registry-url: ${{ inputs['registry-url'] }}
                   scope: ${{ inputs.scope }}
-
-            - name: Install dependencies
-              working-directory: ${{ inputs['package-directory'] }}
-              shell: bash
-              run: npm ci
-
-            - name: Install test dependencies
-              if: ${{ inputs['test-script'] != '' && inputs['test-directory'] != '' && inputs['test-directory'] != inputs['package-directory'] }}
-              working-directory: ${{ inputs['test-directory'] }}
-              shell: bash
-              run: npm ci
-
-            - name: Run tests
-              if: ${{ inputs['test-script'] != '' }}
-              working-directory: ${{ inputs['test-directory'] != '' && inputs['test-directory'] || inputs['package-directory'] }}
-              shell: bash
-              run: |
-                  script="${{ inputs['test-script'] }}"
-                  echo "🧪 Running npm run $script..."
-                  npm run "$script"
-
-            - name: Publish npm package
-              working-directory: ${{ inputs['package-directory'] }}
-              shell: bash
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets['token-github-packages'] }}
-              run: |
-                  debug="${{ inputs['ci-debug-mode'] }}"
-                  dry_run="${{ inputs['dry-run'] }}"
-                  tag="${{ inputs.tag }}"
-                  access="${{ inputs.access }}"
-
-                  if [[ "$debug" == "true" ]]; then
-                    echo "🔍 Debug mode is ON"
-                    echo "🔍 package-directory: ${{ inputs['package-directory'] }}"
-                    echo "🔍 registry-url: ${{ inputs['registry-url'] }}"
-                    echo "🔍 scope: ${{ inputs.scope }}"
-                    echo "🔍 tag: $tag"
-                    echo "🔍 access: $access"
-                    echo "🔍 dry-run: $dry_run"
-                    echo "🔍 test-script: ${{ inputs['test-script'] }}"
-                    echo "🔍 test-directory: ${{ inputs['test-directory'] }}"
-                  fi
-
-                  ARGS="--access $access --tag $tag"
-                  if [[ "$dry_run" == "true" ]]; then
-                    ARGS="$ARGS --dry-run"
-                    echo "ℹ️ Dry run mode enabled; package will not be published."
-                  fi
-
-                  echo "📦 Publishing npm package from ${{ inputs['package-directory'] }}..."
-                  npm publish $ARGS
+                  tag: ${{ inputs.tag }}
+                  test-directory: ${{ inputs['test-directory'] }}
+                  test-script: ${{ inputs['test-script'] }}
+                  token-github-packages: ${{ secrets['token-github-packages'] }}

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,3 +1,0 @@
-# TODOS
-
-- need to test everything

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,3 +1,4 @@
 # TODOS
 
 - how to handle the release stuff? (use the composite action and validate the changelog stuff is in place?)
+    -- the demo should clean up the release stuff when the relevant input is `true`

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,4 +1,3 @@
 # TODOS
 
-- how to handle the release stuff? (use the composite action and validate the changelog stuff is in place?)
-    -- the demo should clean up the release stuff when the relevant input is `true`
+- need to test everything

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,3 @@
+# TODOS
+
+- how to handle the release stuff? (use the composite action and validate the changelog stuff is in place?)

--- a/docs/plan/GHS-1.0.19/requirements.md
+++ b/docs/plan/GHS-1.0.19/requirements.md
@@ -1,0 +1,17 @@
+# Requirements: Reusable npm Publish Workflow
+
+**Acceptance Criteria:**
+
+- [  ] There is a reusable workflow that can publish npm packages from any GitHub workflow.
+- [  ] The reusable workflow supports publishing to GitHub Packages with scoped package names and configurable registry settings.
+- [  ] There is a demo workflow in this repository that exercises the reusable npm publish workflow end to end.
+- [  ] There is an easy-to-understand README.md that explains inputs, outputs, auth requirements, and how to use the reusable workflow safely.
+- [  ] The workflow only publishes from trusted refs such as `main` or release tags, not from pull requests or untrusted branches.
+
+## Non-Functional Requirements
+
+- **Performance:** N/A
+- **Availability:** N/A
+- **Security:** Use least-privilege credentials for publishing, keep tokens in GitHub secrets, avoid printing secrets to logs, and do not publish from untrusted events.
+- **Accessibility:** N/A
+- **Scalability:** N/A

--- a/docs/plan/GHS-1.0.19/requirements.md
+++ b/docs/plan/GHS-1.0.19/requirements.md
@@ -2,11 +2,11 @@
 
 **Acceptance Criteria:**
 
-- [  ] There is a reusable workflow that can publish npm packages from any GitHub workflow.
-- [  ] The reusable workflow supports publishing to GitHub Packages with scoped package names and configurable registry settings.
-- [  ] There is a demo workflow in this repository that exercises the reusable npm publish workflow end to end.
-- [  ] There is an easy-to-understand README.md that explains inputs, outputs, auth requirements, and how to use the reusable workflow safely.
-- [  ] The workflow only publishes from trusted refs such as `main` or release tags, not from pull requests or untrusted branches.
+- [ X ] There is a reusable workflow that can publish npm packages from any GitHub workflow.
+- [ X ] The reusable workflow supports publishing to GitHub Packages with scoped package names and configurable registry settings.
+- [ X ] There is a demo workflow in this repository that exercises the reusable npm publish workflow end to end.
+- [ X ] There is an easy-to-understand README.md that explains inputs, outputs, auth requirements, and how to use the reusable workflow safely.
+- [ X ] The workflow only publishes from trusted refs such as `main` or release tags, not from pull requests or untrusted branches.
 
 ## Non-Functional Requirements
 

--- a/extract-changelog/action.yml
+++ b/extract-changelog/action.yml
@@ -52,7 +52,7 @@ runs:
 
           if [ -z "$changelog_file" ]; then
             echo "No changelog file provided. Skipping extraction."
-            changelog-content="This release includes updates to $library_name, but no changelog file was found."
+            changelog_content="This release includes updates to $library_name, but no changelog file was found."
           else 
             while IFS= read -r line || [[ -n "$line" ]]; do
               if [[ "$exact_match_found" == "true" && "$line" =~ $version_section_pattern_generic ]]; then

--- a/github/release/action.yml
+++ b/github/release/action.yml
@@ -103,7 +103,7 @@ runs:
         INPUT_BODY_FILENAME: ${{ inputs.body-filename }}
 
     - name: Create git tag
-      if: ${{ inputs.dry-run == 'false' && steps.prepare.outputs.has_packages > 0 }}
+      if: ${{ inputs.dry-run == 'false' }}
       shell: bash
       run: |
         git config user.name "github-actions[bot]"
@@ -120,13 +120,14 @@ runs:
 
     - name: Create GitHub Release
       id: create-release
-      if: ${{ inputs.dry-run == 'false' && steps.prepare.outputs.has_packages > 0 }}
+      if: ${{ inputs.dry-run == 'false' }}
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       shell: bash
       run: |
         set -euo pipefail
+        shopt -s nullglob
 
         tag_name="${{ steps.prepare.outputs.tag_name }}"
         release_name="${{ steps.prepare.outputs.release_name }}"
@@ -138,17 +139,25 @@ runs:
           prerelease_flag="--prerelease"
         fi
 
-        gh release create "$tag_name" "${release_files[@]}" \
-          --repo "$GITHUB_REPOSITORY" \
-          --title "$release_name" \
-          --notes-file "$release_notes_path" \
-          $prerelease_flag
+        if [ "${#release_files[@]}" -gt 0 ]; then
+          gh release create "$tag_name" "${release_files[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$release_name" \
+            --notes-file "$release_notes_path" \
+            $prerelease_flag
+        else
+          gh release create "$tag_name" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$release_name" \
+            --notes-file "$release_notes_path" \
+            $prerelease_flag
+        fi
 
         release_url=$(gh release view "$tag_name" --repo "$GITHUB_REPOSITORY" --json url --jq .url)
         echo "url=$release_url" >> "$GITHUB_OUTPUT"
 
     - name: Add release URL to workflow summary
-      if: ${{ inputs.dry-run == 'false' && steps.prepare.outputs.has_packages > 0 && steps.create-release.outputs.url != '' }}
+      if: ${{ inputs.dry-run == 'false' && steps.create-release.outputs.url != '' }}
       shell: bash
       run: |
         {

--- a/setup-node/README.md
+++ b/setup-node/README.md
@@ -15,6 +15,5 @@ This action installs the requested Node.js version, optionally enables npm cachi
     cache-dependency-path: package-lock.json
     install-dependencies: true
     install-dependencies-directory: src/demo/npm
-    install-dependencies-mode: auto
     token-github-packages: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/setup-node/README.md
+++ b/setup-node/README.md
@@ -16,4 +16,5 @@ This action installs the requested Node.js version, optionally enables npm cachi
     install-dependencies: true
     install-dependencies-directory: src/demo/npm
     install-dependencies-mode: auto
+    token-github-packages: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/setup-node/README.md
+++ b/setup-node/README.md
@@ -1,6 +1,6 @@
 # Setup Node.js Environment
 
-This action installs the requested Node.js version, optionally enables npm caching, and can run `npm ci` for you.
+This action installs the requested Node.js version, optionally enables npm caching, and can run a lockfile-aware npm install for you.
 
 ## Usage
 
@@ -9,7 +9,11 @@ This action installs the requested Node.js version, optionally enables npm cachi
   uses: ./setup-node
   with:
     node-version: 24.x
+    registry-url: https://npm.pkg.github.com
+    scope: '@now-micro'
     cache: true
     cache-dependency-path: package-lock.json
     install-dependencies: true
+    install-dependencies-directory: src/demo/npm
+    install-dependencies-mode: auto
 ```

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -12,10 +12,22 @@ inputs:
     description: 'Install dependencies using npm ci (true/false)'
     required: false
     default: 'false'
+  install-dependencies-directory:
+    description: 'Directory to run the dependency install in.'
+    required: false
+    default: '.'
   node-version:
     description: 'The Node.js version to use'
     required: false
     default: '24.x'
+  registry-url:
+    description: 'npm registry URL to configure for package publication.'
+    required: false
+    default: ''
+  scope:
+    description: 'npm scope to configure for the registry.'
+    required: false
+    default: ''
   show-version:
     description: 'Show Node.js and npm version (true/false)'
     required: false
@@ -27,14 +39,24 @@ runs:
     - name: Set up Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v6
       with:
-        node-version: ${{ inputs.node-version }}
-        cache: ${{ inputs.cache == 'true' && 'npm' || '' }}
         cache-dependency-path: ${{ inputs.cache-dependency-path || '' }}
+        cache: ${{ inputs.cache == 'true' && 'npm' || '' }}
+        node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.registry-url || '' }}
+        scope: ${{ inputs.scope || '' }}
 
     - name: Install dependencies
       if: ${{ inputs.install-dependencies == 'true' }}
+      working-directory: ${{ inputs.install-dependencies-directory || '.' }}
       shell: bash
-      run: npm ci
+      run: |
+        if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
+          echo "📦 Installing dependencies with npm ci"
+          npm ci
+        else
+          echo "⚠️ No lockfile found; installing dependencies with npm install --no-package-lock"
+          npm install --no-package-lock --no-audit --no-fund
+        fi
 
     - name: Show Node.js and npm version
       shell: bash

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -32,12 +32,18 @@ inputs:
     description: 'Show Node.js and npm version (true/false)'
     required: false
     default: 'false'
+  token-github-packages:
+    description: 'Token used to authenticate to the npm registry. Passed as NODE_AUTH_TOKEN.'
+    required: false
+    default: ''
   
 runs:
   using: "composite"
   steps:
     - name: Set up Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v6
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs['token-github-packages'] }}
       with:
         cache-dependency-path: ${{ inputs.cache-dependency-path || '' }}
         cache: ${{ inputs.cache == 'true' && 'npm' || '' }}
@@ -49,6 +55,8 @@ runs:
       if: ${{ inputs.install-dependencies == 'true' }}
       working-directory: ${{ inputs.install-dependencies-directory || '.' }}
       shell: bash
+      env:
+        NODE_AUTH_TOKEN: ${{ inputs['token-github-packages'] }}
       run: |
         if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
           echo "📦 Installing dependencies with npm ci"

--- a/src/demo/npm/CHANGELOG.md
+++ b/src/demo/npm/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [1.0.0]
+
+### Added
+- Initial demo package used by the npm publish workflow tests.
+- Math helper functions exercised by the package test suite.

--- a/src/demo/npm/index.js
+++ b/src/demo/npm/index.js
@@ -1,0 +1,65 @@
+'use strict';
+
+/**
+ * Adds two numbers.
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ */
+function add(a, b) {
+    return a + b;
+}
+
+/**
+ * Subtracts b from a.
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ */
+function subtract(a, b) {
+    return a - b;
+}
+
+/**
+ * Multiplies two numbers.
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ */
+function multiply(a, b) {
+    return a * b;
+}
+
+/**
+ * Divides a by b. Throws if b is zero.
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ */
+function divide(a, b) {
+    if (b === 0) throw new Error('Division by zero');
+    return a / b;
+}
+
+/**
+ * Clamps a value between min and max (inclusive).
+ * @param {number} value
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Returns the absolute difference between two numbers.
+ * @param {number} a
+ * @param {number} b
+ * @returns {number}
+ */
+function absDiff(a, b) {
+    return Math.abs(a - b);
+}
+
+module.exports = { add, subtract, multiply, divide, clamp, absDiff };

--- a/src/demo/npm/index.test.js
+++ b/src/demo/npm/index.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { add, subtract, multiply, divide, clamp, absDiff } = require('./index');
+
+// ── add ───────────────────────────────────────────────────────────────────────
+
+test('add: positive numbers', () => {
+    assert.strictEqual(add(2, 3), 5);
+});
+
+test('add: negative numbers', () => {
+    assert.strictEqual(add(-4, -6), -10);
+});
+
+test('add: mixed sign', () => {
+    assert.strictEqual(add(10, -3), 7);
+});
+
+test('add: floats', () => {
+    assert.ok(Math.abs(add(0.1, 0.2) - 0.3) < Number.EPSILON * 10);
+});
+
+test('add: identity (n + 0 = n)', () => {
+    assert.strictEqual(add(42, 0), 42);
+});
+
+// ── subtract ──────────────────────────────────────────────────────────────────
+
+test('subtract: basic', () => {
+    assert.strictEqual(subtract(10, 4), 6);
+});
+
+test('subtract: result is negative', () => {
+    assert.strictEqual(subtract(3, 8), -5);
+});
+
+test('subtract: same value yields zero', () => {
+    assert.strictEqual(subtract(7, 7), 0);
+});
+
+test('subtract: negative operand', () => {
+    assert.strictEqual(subtract(-2, -5), 3);
+});
+
+// ── multiply ──────────────────────────────────────────────────────────────────
+
+test('multiply: positive numbers', () => {
+    assert.strictEqual(multiply(3, 4), 12);
+});
+
+test('multiply: by zero', () => {
+    assert.strictEqual(multiply(99, 0), 0);
+});
+
+test('multiply: negative × positive', () => {
+    assert.strictEqual(multiply(-3, 5), -15);
+});
+
+test('multiply: negative × negative', () => {
+    assert.strictEqual(multiply(-4, -6), 24);
+});
+
+test('multiply: identity (n × 1 = n)', () => {
+    assert.strictEqual(multiply(7, 1), 7);
+});
+
+// ── divide ────────────────────────────────────────────────────────────────────
+
+test('divide: basic', () => {
+    assert.strictEqual(divide(10, 2), 5);
+});
+
+test('divide: result is a fraction', () => {
+    assert.strictEqual(divide(7, 2), 3.5);
+});
+
+test('divide: negative dividend', () => {
+    assert.strictEqual(divide(-9, 3), -3);
+});
+
+test('divide: both negative', () => {
+    assert.strictEqual(divide(-12, -4), 3);
+});
+
+test('divide: by zero throws', () => {
+    assert.throws(() => divide(5, 0), /Division by zero/);
+});
+
+// ── clamp ─────────────────────────────────────────────────────────────────────
+
+test('clamp: value within range is unchanged', () => {
+    assert.strictEqual(clamp(5, 1, 10), 5);
+});
+
+test('clamp: value below min returns min', () => {
+    assert.strictEqual(clamp(-5, 0, 100), 0);
+});
+
+test('clamp: value above max returns max', () => {
+    assert.strictEqual(clamp(200, 0, 100), 100);
+});
+
+test('clamp: value equal to min', () => {
+    assert.strictEqual(clamp(0, 0, 10), 0);
+});
+
+test('clamp: value equal to max', () => {
+    assert.strictEqual(clamp(10, 0, 10), 10);
+});
+
+// ── absDiff ───────────────────────────────────────────────────────────────────
+
+test('absDiff: a > b', () => {
+    assert.strictEqual(absDiff(10, 3), 7);
+});
+
+test('absDiff: b > a', () => {
+    assert.strictEqual(absDiff(3, 10), 7);
+});
+
+test('absDiff: equal values', () => {
+    assert.strictEqual(absDiff(5, 5), 0);
+});
+
+test('absDiff: negative values', () => {
+    assert.strictEqual(absDiff(-3, -8), 5);
+});
+
+test('absDiff: mixed sign', () => {
+    assert.strictEqual(absDiff(-4, 6), 10);
+});

--- a/src/demo/npm/package.json
+++ b/src/demo/npm/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@now-micro/demo-npm",
+  "version": "1.0.0",
+  "description": "Simple math utility functions (add, subtract, multiply, divide, clamp, absDiff). Demo package for the reusable npm publish workflow.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test index.test.js"
+  },
+  "keywords": ["demo"],
+  "author": "Now-Micro",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}


### PR DESCRIPTION
This pull request introduces a reusable, secure, and configurable workflow for publishing npm packages to GitHub Packages, along with comprehensive documentation and demo/test integrations. The main focus is on enabling safe, flexible npm publishing from GitHub Actions, with clear usage instructions and robust input validation.

**Reusable npm publish workflow:**

* Added `.github/workflows/reusable-npm-publish.yml`, a reusable workflow that validates inputs, ensures correct permissions, configures Node.js, and publishes npm packages to GitHub Packages, supporting options for access level, dry-run, custom registry, scope, and pre-publish test scripts. The workflow only runs on trusted refs (e.g., `main`) and requires a least-privilege PAT for authentication.
* Created `.github/actions/npm-publish-workflow/action.yml`, a composite action encapsulating the npm install, test, and publish steps, as well as optional GitHub release creation, with flexible inputs for CI/debug, directory selection, and tagging.

**Demo and validation:**

* Added `.github/actions/demo-npm-publish/action.yml` and `.github/workflows/demo-npm-publish.yml` to provide a full end-to-end demonstration and test of the reusable npm publish workflow, including dry-run and error scenarios, test assertions, and cleanup of published packages and releases. [[1]](diffhunk://#diff-beb992c216f5d62d4bfa13a031afd1c97339a49cfe33d008764f80aaf820cfa7R1-R193) [[2]](diffhunk://#diff-bfdcdc46714816a024ab14a3ea2a83509b207a27629b189fd451604cae6fc558R1-R31)
* Integrated the demo into `.github/actions/run-demo-workflows/action.yml` to ensure the demo runs as part of the overall demo suite.

**Documentation and requirements:**

* Extended `.github/workflows/README.md` with a detailed section on the npm publish workflow, including what it does, all inputs and secrets, security notes, and usage examples, making it easy for others to adopt and use safely. [[1]](diffhunk://#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffbR33-R38) [[2]](diffhunk://#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffbR360-R416)
* Added `docs/plan/GHS-1.0.19/requirements.md` to record acceptance criteria and non-functional requirements for the reusable npm publish workflow.

**Miscellaneous:**

* Added a simple TODO list in `TODOS.md` to track remaining manual testing.