### PR TITLE
fix(configure-source): detection issues and add wildcards for authorize composite action

### DIFF
--- a/authorize/README.md
+++ b/authorize/README.md
@@ -8,6 +8,34 @@ The composite action wraps `authorize.js`, which reads `permissions.json` from t
 
 When the actor is allowed, the action logs a success message. When the actor is not allowed, it exits with code `1` and prints a clear reason so the workflow can fail fast.
 
+### Permissions file structure
+
+`permissions.json` is a two-level map: the top-level key is the repository name (without the org prefix) and the second-level key is the workflow filename. Both levels support the wildcard key `"*"`:
+
+| Top-level key | Second-level key | Meaning |
+|---|---|---|
+| `"RepoName"` | `"workflow.yml"` | Exact match — specific repo and specific workflow |
+| `"RepoName"` | `"*"` | Any workflow in this specific repo |
+| `"*"` | `"workflow.yml"` | This specific workflow in any repo |
+| `"*"` | `"*"` | Any workflow in any repo (universal permission) |
+
+All matching entries are evaluated together. An actor is authorized if they appear in **any** applicable list, so a universal `"*"/"*"` entry grants access everywhere while more specific entries can grant access to a narrower scope alongside it.
+
+**Example:**
+
+```json
+{
+    "*": {
+        "*": ["Bernard Carter", "Hilton Dahl"]
+    },
+    "CodeBits": {
+        "release-nuget.yml": ["Adam Major"]
+    }
+}
+```
+
+Here `Bernard Carter` and `Hilton Dahl` can trigger any workflow in any repository, while `Adam Major` can only trigger `release-nuget.yml` in `CodeBits`.
+
 ## `populateUsers`
 
 `populateUsers.js` is the companion script that helps maintain `users.json`. It fetches members from the `Now-Micro` GitHub organization, looks up each member's display name, and rewrites `users.json` as a simple map of GitHub login to a single name string.

--- a/authorize/README.md
+++ b/authorize/README.md
@@ -21,6 +21,8 @@ When the actor is allowed, the action logs a success message. When the actor is 
 
 All matching entries are evaluated together. An actor is authorized if they appear in **any** applicable list, so a universal `"*"/"*"` entry grants access everywhere while more specific entries can grant access to a narrower scope alongside it.
 
+Each leaf array holds the actors permitted for that entry. Each element may be either a **GitHub login** (e.g. `"nlhuey"`) or a **display name** that maps to a login in `users.json` (e.g. `"Nick Huey"`). Both forms are resolved at runtime, so you may mix them freely within the same array.
+
 **Example:**
 
 ```json

--- a/authorize/authorize.js
+++ b/authorize/authorize.js
@@ -135,21 +135,43 @@ function run() {
         process.exit(1);
     }
 
-    const repoPerms = findCaseInsensitive(permissions, repoName);
-    if (!repoPerms) {
-        console.error(`❌ No permissions defined for repository '${repoName}'.`);
-        console.error(`   Actor '${actor}' is not authorized. Add an entry for '${repoName}' in permissions.json.`);
+    // Gather all applicable allowed-actor lists, respecting '*' wildcards at both levels.
+    // Checks (all contribute): repo/workflow, repo/*, */workflow, */*
+    const exactRepoPerms = findCaseInsensitive(permissions, repoName);
+    const wildcardRepoPerms = repoName !== '*' ? findCaseInsensitive(permissions, '*') : null;
+
+    const allowedActorLists = [];
+
+    if (exactRepoPerms) {
+        const exact = findCaseInsensitive(exactRepoPerms, workflowFilename);
+        if (exact !== undefined) allowedActorLists.push(Array.isArray(exact) ? exact : []);
+        if (workflowFilename !== '*') {
+            const wildcardWf = findCaseInsensitive(exactRepoPerms, '*');
+            if (wildcardWf !== undefined) allowedActorLists.push(Array.isArray(wildcardWf) ? wildcardWf : []);
+        }
+    }
+
+    if (wildcardRepoPerms) {
+        const exact = findCaseInsensitive(wildcardRepoPerms, workflowFilename);
+        if (exact !== undefined) allowedActorLists.push(Array.isArray(exact) ? exact : []);
+        if (workflowFilename !== '*') {
+            const wildcardWf = findCaseInsensitive(wildcardRepoPerms, '*');
+            if (wildcardWf !== undefined) allowedActorLists.push(Array.isArray(wildcardWf) ? wildcardWf : []);
+        }
+    }
+
+    if (allowedActorLists.length === 0) {
+        if (!exactRepoPerms && !wildcardRepoPerms) {
+            console.error(`❌ No permissions defined for repository '${repoName}'.`);
+            console.error(`   Actor '${actor}' is not authorized. Add an entry for '${repoName}' or '*' in permissions.json.`);
+        } else {
+            console.error(`❌ No permissions defined for workflow '${workflowFilename}' under repository '${repoName}'.`);
+            console.error(`   Actor '${actor}' is not authorized. Add an entry for '${workflowFilename}' or '*' under '${repoName}' or '*' in permissions.json.`);
+        }
         process.exit(1);
     }
 
-    const allowedActors = findCaseInsensitive(repoPerms, workflowFilename);
-    if (!allowedActors) {
-        console.error(`❌ No permissions defined for workflow '${workflowFilename}' under repository '${repoName}'.`);
-        console.error(`   Actor '${actor}' is not authorized. Add an entry for '${workflowFilename}' under '${repoName}' in permissions.json.`);
-        process.exit(1);
-    }
-
-    const allowedActorList = Array.isArray(allowedActors) ? allowedActors : [];
+    const allowedActorList = allowedActorLists.flat();
     let authorizedByAlias = '';
     const actorLower = actor.toLowerCase();
     const actorDisplayLower = actorAlias.toLowerCase();

--- a/authorize/authorize.test.js
+++ b/authorize/authorize.test.js
@@ -307,3 +307,112 @@ test('debug mode enabled prints 🔍 logs', () => {
     assert.match(r.out, /🔍 Workflow ref:/);
     assert.match(r.out, /🔍 Permissions:/);
 });
+
+// ---------------------------------------------------------------------------
+// Wildcard permission tests
+// ---------------------------------------------------------------------------
+
+test('actor in */* is authorized for any repo and workflow', () => {
+    const { actionDir } = makeActionDir({ '*': { '*': ['Beschuetzer'] } });
+    const r = runWith(makeEnv({ GITHUB_ACTION_PATH: actionDir }));
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
+});
+
+test('actor in */* is authorized for an entirely different repo and workflow', () => {
+    const { actionDir } = makeActionDir({ '*': { '*': ['Beschuetzer'] } });
+    const r = runWith(makeEnv({
+        GITHUB_ACTION_PATH: actionDir,
+        INPUT_REPOSITORY: 'Now-Micro/SomeOtherRepo',
+        INPUT_WORKFLOW_REF: 'Now-Micro/SomeOtherRepo/.github/workflows/deploy.yml@refs/heads/main'
+    }));
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
+});
+
+test('actor NOT listed in */* is still unauthorized', () => {
+    const { actionDir } = makeActionDir({ '*': { '*': ['OtherUser'] } });
+    const r = runWith(makeEnv({ GITHUB_ACTION_PATH: actionDir }));
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /not authorized/);
+});
+
+test('actor in */specific-workflow is authorized for that workflow in any repo', () => {
+    const { actionDir } = makeActionDir({ '*': { 'release.yml': ['Beschuetzer'] } });
+    const r = runWith(makeEnv({ GITHUB_ACTION_PATH: actionDir }));
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
+});
+
+test('actor in */release.yml is not authorized for a different workflow', () => {
+    const { actionDir } = makeActionDir({ '*': { 'release.yml': ['Beschuetzer'] } });
+    const r = runWith(makeEnv({
+        GITHUB_ACTION_PATH: actionDir,
+        INPUT_WORKFLOW_REF: 'Now-Micro/CodeBits/.github/workflows/deploy.yml@refs/heads/main'
+    }));
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /No permissions defined for workflow/);
+});
+
+test('actor in specific-repo/* is authorized for any workflow in that repo', () => {
+    const { actionDir } = makeActionDir({ 'CodeBits': { '*': ['Beschuetzer'] } });
+    const r = runWith(makeEnv({ GITHUB_ACTION_PATH: actionDir }));
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
+});
+
+test('actor in specific-repo/* is not authorized for a different repo', () => {
+    const { actionDir } = makeActionDir({ 'CodeBits': { '*': ['Beschuetzer'] } });
+    const r = runWith(makeEnv({
+        GITHUB_ACTION_PATH: actionDir,
+        INPUT_REPOSITORY: 'Now-Micro/WarrantyService',
+        INPUT_WORKFLOW_REF: 'Now-Micro/WarrantyService/.github/workflows/release.yml@refs/heads/main'
+    }));
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /No permissions defined for repository/);
+});
+
+test('*/* grants access when actor is absent from specific repo/workflow entry', () => {
+    const { actionDir } = makeActionDir({
+        '*': { '*': ['Beschuetzer'] },
+        'CodeBits': { 'release.yml': ['Test123'] }
+    });
+    const r = runWith(makeEnv({ GITHUB_ACTION_PATH: actionDir }));
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
+});
+
+test('specific repo/workflow entry grants access when actor absent from */*', () => {
+    const { actionDir } = makeActionDir({
+        '*': { '*': ['OtherUser'] },
+        'CodeBits': { 'release.yml': ['Beschuetzer'] }
+    });
+    const r = runWith(makeEnv({ GITHUB_ACTION_PATH: actionDir }));
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
+});
+
+test('*/* supports alias resolution via users.json', () => {
+    const { actionDir } = makeActionDir({ '*': { '*': ['Adam Major'] } });
+    const r = runWith(makeEnv({ GITHUB_ACTION_PATH: actionDir }));
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
+});
+
+test('repo/* supports alias resolution via users.json', () => {
+    const { actionDir } = makeActionDir({ 'CodeBits': { '*': ['Adam Major'] } });
+    const r = runWith(makeEnv({ GITHUB_ACTION_PATH: actionDir }));
+    assert.strictEqual(r.exitCode, 0);
+    assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
+});
+
+test('*/* repo entry present but no workflow match still errors on workflow not authorized', () => {
+    // There IS a wildcard repo entry but the workflow listed doesn't match and there's no */* entry
+    const { actionDir } = makeActionDir({ '*': { 'deploy.yml': ['Beschuetzer'] } });
+    const r = runWith(makeEnv({
+        GITHUB_ACTION_PATH: actionDir,
+        INPUT_WORKFLOW_REF: 'Now-Micro/CodeBits/.github/workflows/release.yml@refs/heads/main'
+    }));
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err, /No permissions defined for workflow/);
+});

--- a/authorize/authorize.test.js
+++ b/authorize/authorize.test.js
@@ -406,7 +406,7 @@ test('repo/* supports alias resolution via users.json', () => {
     assert.match(r.out, /✅.*Beschuetzer.*is authorized/);
 });
 
-test('*/* repo entry present but no workflow match still errors on workflow not authorized', () => {
+test('wildcard repo entry with specific workflow but no workflow match still errors on workflow not authorized', () => {
     // There IS a wildcard repo entry but the workflow listed doesn't match and there's no */* entry
     const { actionDir } = makeActionDir({ '*': { 'deploy.yml': ['Beschuetzer'] } });
     const r = runWith(makeEnv({

--- a/authorize/permissions.json
+++ b/authorize/permissions.json
@@ -1,41 +1,25 @@
 {
-    "aSpIRe-DEMO": {
-        "auth-sucCEss.yml": [
-            "Adam Major"
-        ]
-    },
-    "CodeBits": {
-        "release-nuget.yml": [
+    "*": {
+        "*": [
             "Adam Major",
             "Bernard Carter",
             "Hilton Dahl"
         ]
     },
+    "CodeBits": {
+        "release-nuget.yml": []
+    },
     "CSI-Connector": {
         "cd-docker.yml": [
-            "Adam Major",
-            "Bernard Carter",
-            "Hilton Dahl",
             "Stephen James"
         ],
         "release-nuget.yml": [
-            "Adam Major",
-            "Bernard Carter",
-            "Hilton Dahl",
             "Stephen James"
         ]
     },
     "WarrantyService": {
         "cd-docker.yml": [
-            "Adam Major",
-            "Bernard Carter",
-            "Hilton Dahl",
             "Stephen James"
-        ],
-        "release-nuget.yml": [
-            "Adam Major",
-            "Bernard Carter",
-            "Hilton Dahl"
         ]
     }
 }

--- a/authorize/permissions.json
+++ b/authorize/permissions.json
@@ -6,9 +6,6 @@
             "Hilton Dahl"
         ]
     },
-    "CodeBits": {
-        "release-nuget.yml": []
-    },
     "CSI-Connector": {
         "cd-docker.yml": [
             "Stephen James"

--- a/nuget/configure-sources/configure-sources.js
+++ b/nuget/configure-sources/configure-sources.js
@@ -57,26 +57,62 @@ function parseRegisteredSources(listOutput) {
     if (!listOutput) return entries;
     const lines = listOutput.split(/\r?\n/);
     for (let i = 0; i < lines.length; i += 1) {
-        const match = lines[i].match(/^\s*\d+\.\s+([^\[]+)/);
+        const match = lines[i].match(/^\s*(?:\d+\.\s+)?(.+?)\s+\[(?:Enabled|Disabled)\]\s*$/);
         if (!match) continue;
         const name = match[1].trim();
         let url = '';
-        if (i + 1 < lines.length) {
-            const candidate = lines[i + 1].trim();
+        for (let j = i + 1; j < lines.length; j += 1) {
+            const candidate = lines[j].trim();
+            if (!candidate) continue;
             if (candidate.startsWith('http')) {
                 url = candidate;
             }
+            break;
         }
         entries.push({ name, url });
     }
     return entries;
 }
 
+function stringifyExecError(err) {
+    if (!err) return '';
+
+    const parts = [];
+    if (err.stdout) {
+        const stdout = String(err.stdout).trim();
+        if (stdout) parts.push(`stdout:\n${stdout}`);
+    }
+    if (err.stderr) {
+        const stderr = String(err.stderr).trim();
+        if (stderr) parts.push(`stderr:\n${stderr}`);
+    }
+    if (err.message) {
+        parts.push(`message: ${err.message}`);
+    }
+
+    return parts.join('\n');
+}
+
+function isDuplicateSourceError(err) {
+    const text = stringifyExecError(err).toLowerCase();
+    return /already exists|same name|duplicate|cannot add a source with the same name/.test(text);
+}
+
 function runDotnet(exec, args, logFn, debugMode) {
     if (debugMode) {
         logFn(`exec: dotnet ${args.join(' ')}`);
     }
-    return exec('dotnet', args, { encoding: 'utf8' });
+    try {
+        return exec('dotnet', args, { encoding: 'utf8' });
+    } catch (err) {
+        const details = stringifyExecError(err);
+        const message = details
+            ? `dotnet ${args.join(' ')} failed:\n${details}`
+            : `dotnet ${args.join(' ')} failed.`;
+        const wrapped = new Error(message);
+        wrapped.cause = err;
+        throw wrapped;
+    }
 }
 
 function configureSources(env = process.env, options = {}) {
@@ -151,7 +187,7 @@ function configureSources(env = process.env, options = {}) {
             ], logFn, debugMode);
         } else {
             logFn(`Adding NuGet source '${entry.name}'...`);
-            runDotnet(exec, [
+            const addArgs = [
                 'nuget',
                 'add',
                 'source',
@@ -163,7 +199,29 @@ function configureSources(env = process.env, options = {}) {
                 '--name',
                 entry.name,
                 entry.url,
-            ], logFn, debugMode);
+            ];
+            try {
+                runDotnet(exec, addArgs, logFn, debugMode);
+            } catch (err) {
+                if (!isDuplicateSourceError(err)) {
+                    throw err;
+                }
+
+                logFn(`NuGet source '${entry.name}' may already exist. Retrying as an update...`);
+                runDotnet(exec, [
+                    'nuget',
+                    'update',
+                    'source',
+                    entry.name,
+                    '--username',
+                    entry.username,
+                    '--password',
+                    entry.password,
+                    '--store-password-in-clear-text',
+                    '--source',
+                    entry.url,
+                ], logFn, debugMode);
+            }
         }
     }
 

--- a/nuget/configure-sources/configure-sources.test.js
+++ b/nuget/configure-sources/configure-sources.test.js
@@ -209,6 +209,22 @@ test('special characters in name are escaped when matching', () => {
     assert.ok(execStub.calls.some(call => call.args[1] === 'update'));
 });
 
+test('parses source entries with disabled status and blank lines before urls', () => {
+    const parsed = parseRegisteredSources([
+        'Registered Sources:',
+        '  1.  Foo [Disabled]',
+        '',
+        '      https://example.invalid/foo/index.json',
+        '  2.  Bar [Enabled]',
+        '      https://example.invalid/bar/index.json',
+    ].join('\n'));
+
+    assert.deepStrictEqual(parsed, [
+        { name: 'Foo', url: 'https://example.invalid/foo/index.json' },
+        { name: 'Bar', url: 'https://example.invalid/bar/index.json' },
+    ]);
+});
+
 test('matches existing source regardless of casing', () => {
     const execStub = createExecStub(makeListOutput(['CodeBits']));
     const env = {
@@ -267,6 +283,40 @@ test('run logs errors and exits when configureSources throws', () => {
 
     assert.ok(errors.length >= 1);
     assert.deepStrictEqual(exitCodes, [1]);
+});
+
+test('duplicate source add failures retry as an update', () => {
+    const calls = [];
+    const exec = (cmd, args, opts = {}) => {
+        calls.push({ cmd, args, opts });
+        if (args[0] === 'nuget' && args[1] === 'list') {
+            return makeListOutput([]);
+        }
+        if (args[0] === 'nuget' && args[1] === 'add') {
+            const error = new Error('Command failed: dotnet nuget add source');
+            error.stdout = '';
+            error.stderr = "A source with the name 'Now-Micro' already exists.";
+            throw error;
+        }
+        return '';
+    };
+
+    const env = {
+        INPUT_NAMES: 'Now-Micro',
+        INPUT_USERNAMES: 'user',
+        INPUT_PASSWORDS: 'pass',
+        INPUT_URLS: 'https://nuget.pkg.github.com/Now-Micro/index.json',
+    };
+
+    const logs = [];
+    const entries = configureSources(env, {
+        exec,
+        log: message => logs.push(message),
+    });
+
+    assert.strictEqual(entries.length, 1);
+    assert.ok(logs.some(line => line.includes('Retrying as an update')));
+    assert.ok(calls.some(call => call.args[1] === 'update'), 'expected fallback update command to run');
 });
 
 test('parseRegisteredSources skips entries without urls', () => {
@@ -330,5 +380,43 @@ test('run uses default error logger when configureSources throws', () => {
     }
 
     assert.deepStrictEqual(exitCodes, [1]);
-    assert.ok(errors.some(line => line.includes('Error: boom')), 'expected default error logger to emit the caught stack trace');
+    assert.ok(errors.some(line => line.includes('dotnet nuget list source failed')),
+        'expected default error logger to emit the wrapped dotnet command failure');
+    assert.ok(errors.some(line => line.includes('message: boom')),
+        'expected default error logger to include the underlying exec error message');
+});
+
+test('run includes dotnet stderr when a command fails', () => {
+    const env = {
+        INPUT_NAMES: 'CodeBits',
+        INPUT_USERNAMES: 'user',
+        INPUT_PASSWORDS: 'pass',
+        INPUT_URLS: 'https://nuget.pkg.github.com/owner/index.json',
+    };
+    const exitCodes = [];
+    const errors = [];
+    const originalStderr = process.stderr.write;
+    process.stderr.write = (chunk, ...rest) => {
+        errors.push(String(chunk));
+        return true;
+    };
+    try {
+        run(env, {
+            exec: (cmd, args) => {
+                if (args[0] === 'nuget' && args[1] === 'list') {
+                    return makeListOutput([]);
+                }
+                const error = new Error('Command failed');
+                error.stderr = 'A source with the name already exists.';
+                throw error;
+            },
+            exit: code => exitCodes.push(code),
+        });
+    } finally {
+        process.stderr.write = originalStderr;
+    }
+
+    assert.deepStrictEqual(exitCodes, [1]);
+    assert.ok(errors.some(line => line.includes('A source with the name already exists.')),
+        'expected default error logger to include the underlying dotnet stderr');
 });


### PR DESCRIPTION
This pull request introduces several improvements and new features to both the GitHub Actions authorization logic and the NuGet source configuration scripts. The main highlights include enhanced wildcard support for permissions, better error handling and diagnostics for NuGet source management, and expanded test coverage to ensure robust behavior.

**Authorization system improvements:**

* Added support for two-level wildcards in `permissions.json` (e.g., `"*"` for any repository or workflow), allowing for more flexible and concise permission definitions. The authorization logic now evaluates all matching entries and grants access if the actor is listed in any applicable entry. (`authorize/authorize.js`, `authorize/README.md`) [[1]](diffhunk://#diff-373aa46e990b660f96044d8ea50e5bae1c5340e56d137519054f3b2304f39567L138-R174) [[2]](diffhunk://#diff-644efef982b614d90e83a6fe07061a264dfbf548a40f2e52b4141ae208555be7R11-R40)
* Updated `permissions.json` to use a universal `"*"/"*"` entry, simplifying the configuration and reducing duplication. (`authorize/permissions.json`)
* Added comprehensive tests for wildcard permission scenarios, covering all combinations of repo/workflow wildcards and actor alias resolution. (`authorize/authorize.test.js`)

**NuGet source configuration enhancements:**

* Improved parsing of `dotnet nuget list source` output to handle both enabled/disabled sources and to be more robust against blank lines and formatting variations. (`nuget/configure-sources/configure-sources.js`, `nuget/configure-sources/configure-sources.test.js`) [[1]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L60-R115) [[2]](diffhunk://#diff-1edb479ec892c5414101c9a1f73901e67e546ec0a25314537a5a5d8529492047R212-R227)
* Enhanced error handling in `runDotnet` to wrap failures with detailed stdout/stderr/message output, and added logic to detect duplicate source errors. If adding a source fails due to duplication, the script now retries as an update instead of failing. (`nuget/configure-sources/configure-sources.js`, `nuget/configure-sources/configure-sources.test.js`) [[1]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L60-R115) [[2]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L154-R190) [[3]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6R202-R226) [[4]](diffhunk://#diff-1edb479ec892c5414101c9a1f73901e67e546ec0a25314537a5a5d8529492047R288-R321) [[5]](diffhunk://#diff-1edb479ec892c5414101c9a1f73901e67e546ec0a25314537a5a5d8529492047L333-R421)

These changes provide more maintainable permissions management, clearer diagnostics for NuGet configuration, and greater reliability in CI workflows.