### PR TITLE
fix(configure-source): nuget config missing issue

### DIFF
--- a/nuget/configure-sources/configure-sources.js
+++ b/nuget/configure-sources/configure-sources.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
+const fs = require('fs');
 const { execFileSync } = require('child_process');
+const os = require('os');
+const path = require('path');
 
 function log(message) {
     process.stdout.write(`${message}\n`);
@@ -98,17 +101,33 @@ function isDuplicateSourceError(err) {
     return /already exists|same name|duplicate|cannot add a source with the same name/.test(text);
 }
 
-function runDotnet(exec, args, logFn, debugMode) {
+function createNuGetConfigFile() {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nuget-configure-sources-'));
+    const configFile = path.join(configDir, 'NuGet.Config');
+    const configContents = [
+        '<?xml version="1.0" encoding="utf-8"?>',
+        '<configuration>',
+        '  <packageSources>',
+        '  </packageSources>',
+        '</configuration>',
+    ].join('\n');
+
+    fs.writeFileSync(configFile, configContents, 'utf8');
+    return configFile;
+}
+
+function runDotnet(exec, args, logFn, debugMode, configFile) {
+    const fullArgs = [...args, '--configfile', configFile];
     if (debugMode) {
-        logFn(`exec: dotnet ${args.join(' ')}`);
+        logFn(`exec: dotnet ${fullArgs.join(' ')}`);
     }
     try {
-        return exec('dotnet', args, { encoding: 'utf8' });
+        return exec('dotnet', fullArgs, { encoding: 'utf8' });
     } catch (err) {
         const details = stringifyExecError(err);
         const message = details
-            ? `dotnet ${args.join(' ')} failed:\n${details}`
-            : `dotnet ${args.join(' ')} failed.`;
+            ? `dotnet ${fullArgs.join(' ')} failed:\n${details}`
+            : `dotnet ${fullArgs.join(' ')} failed.`;
         const wrapped = new Error(message);
         wrapped.cause = err;
         throw wrapped;
@@ -119,6 +138,7 @@ function configureSources(env = process.env, options = {}) {
     const exec = options.exec ?? execFileSync;
     const logFn = options.log ?? log;
     const debugMode = parseBool(env.INPUT_DEBUG_MODE);
+    const configFile = options.configFile ?? createNuGetConfigFile();
 
     const entries = zipEntries(env);
     if (debugMode) {
@@ -140,7 +160,7 @@ function configureSources(env = process.env, options = {}) {
     logFn(`Configuring ${entries.length} NuGet source(s)...`);
     for (const entry of entries) {
         logFn(`Processing NuGet source '${entry.name}' (${entry.url})`);
-        const listOutput = runDotnet(exec, ['nuget', 'list', 'source'], logFn, debugMode);
+        const listOutput = runDotnet(exec, ['nuget', 'list', 'source'], logFn, debugMode, configFile);
         if (debugMode) {
             logFn('dotnet nuget list source output:');
             logFn(listOutput);
@@ -162,7 +182,7 @@ function configureSources(env = process.env, options = {}) {
                 '--store-password-in-clear-text',
                 '--source',
                 entry.url,
-            ], logFn, debugMode);
+            ], logFn, debugMode, configFile);
         } else if (existingByUrl) {
             logFn(`NuGet source with URL '${entry.url}' already exists as '${existingByUrl.name}'. Removing old entry before adding '${entry.name}'.`);
             runDotnet(exec, [
@@ -170,7 +190,7 @@ function configureSources(env = process.env, options = {}) {
                 'remove',
                 'source',
                 existingByUrl.name,
-            ], logFn, debugMode);
+            ], logFn, debugMode, configFile);
             logFn(`Adding NuGet source '${entry.name}'...`);
             runDotnet(exec, [
                 'nuget',
@@ -184,7 +204,7 @@ function configureSources(env = process.env, options = {}) {
                 '--name',
                 entry.name,
                 entry.url,
-            ], logFn, debugMode);
+            ], logFn, debugMode, configFile);
         } else {
             logFn(`Adding NuGet source '${entry.name}'...`);
             const addArgs = [
@@ -201,7 +221,7 @@ function configureSources(env = process.env, options = {}) {
                 entry.url,
             ];
             try {
-                runDotnet(exec, addArgs, logFn, debugMode);
+                runDotnet(exec, addArgs, logFn, debugMode, configFile);
             } catch (err) {
                 if (!isDuplicateSourceError(err)) {
                     throw err;
@@ -220,7 +240,7 @@ function configureSources(env = process.env, options = {}) {
                     '--store-password-in-clear-text',
                     '--source',
                     entry.url,
-                ], logFn, debugMode);
+                ], logFn, debugMode, configFile);
             }
         }
     }

--- a/nuget/configure-sources/configure-sources.test.js
+++ b/nuget/configure-sources/configure-sources.test.js
@@ -67,7 +67,7 @@ test('adds a source when the name is not yet registered', () => {
     assert.deepStrictEqual(execStub.calls, [
         {
             cmd: 'dotnet',
-            args: ['nuget', 'list', 'source'],
+            args: ['nuget', 'list', 'source', '--configfile', execStub.calls[0].args[4]],
             opts: { encoding: 'utf8' },
         },
         {
@@ -84,10 +84,34 @@ test('adds a source when the name is not yet registered', () => {
                 '--name',
                 'CodeBits',
                 'https://nuget.pkg.github.com/owner/index.json',
+                '--configfile',
+                execStub.calls[0].args[4],
             ],
             opts: { encoding: 'utf8' },
         },
     ]);
+});
+
+test('dotnet commands always receive an explicit config file', () => {
+    const execStub = createExecStub(makeListOutput([]));
+    const env = {
+        INPUT_NAMES: 'CodeBits',
+        INPUT_USERNAMES: 'user',
+        INPUT_PASSWORDS: 'pass',
+        INPUT_URLS: 'https://nuget.pkg.github.com/owner/index.json',
+    };
+
+    configureSources(env, {
+        exec: execStub.exec,
+        log: () => { },
+    });
+
+    assert.ok(execStub.calls.length >= 2);
+    for (const call of execStub.calls) {
+        assert.ok(call.args.includes('--configfile'), 'expected every dotnet command to include --configfile');
+        const configIndex = call.args.indexOf('--configfile');
+        assert.ok(configIndex >= 0 && typeof call.args[configIndex + 1] === 'string' && call.args[configIndex + 1].includes('NuGet.Config'));
+    }
 });
 
 test('updates a source when the name already exists', () => {
@@ -107,7 +131,7 @@ test('updates a source when the name already exists', () => {
     assert.deepStrictEqual(execStub.calls, [
         {
             cmd: 'dotnet',
-            args: ['nuget', 'list', 'source'],
+            args: ['nuget', 'list', 'source', '--configfile', execStub.calls[0].args[4]],
             opts: { encoding: 'utf8' },
         },
         {
@@ -124,6 +148,8 @@ test('updates a source when the name already exists', () => {
                 '--store-password-in-clear-text',
                 '--source',
                 'https://nuget.pkg.github.com/owner/index.json',
+                '--configfile',
+                execStub.calls[0].args[4],
             ],
             opts: { encoding: 'utf8' },
         },
@@ -380,7 +406,7 @@ test('run uses default error logger when configureSources throws', () => {
     }
 
     assert.deepStrictEqual(exitCodes, [1]);
-    assert.ok(errors.some(line => line.includes('dotnet nuget list source failed')),
+    assert.ok(errors.some(line => line.includes('dotnet nuget list source --configfile')),
         'expected default error logger to emit the wrapped dotnet command failure');
     assert.ok(errors.some(line => line.includes('message: boom')),
         'expected default error logger to include the underlying exec error message');


### PR DESCRIPTION
This pull request updates the NuGet source configuration script to ensure that all `dotnet` commands consistently use an explicit, temporary `NuGet.Config` file. This makes the process more reliable and predictable, especially in CI/CD environments. The changes also improve test coverage to verify this behavior.

**NuGet config file handling:**
* Added a `createNuGetConfigFile` function to generate a temporary `NuGet.Config` file for use with all `dotnet` commands, ensuring isolation from any global or user-level configuration.
* Updated the `runDotnet` function and all invocations to always include the `--configfile` argument, pointing to the generated config file. [[1]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L101-R130) [[2]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6R141) [[3]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L143-R163) [[4]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L165-R193) [[5]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L187-R207) [[6]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L204-R224) [[7]](diffhunk://#diff-585dad60b5afc186b191c853e8a705a0ec150b651c596199006a53d9ca6141f6L223-R243)

**Testing improvements:**
* Updated existing tests to expect the `--configfile` argument in all `dotnet` invocations, ensuring the new behavior is covered. [[1]](diffhunk://#diff-1edb479ec892c5414101c9a1f73901e67e546ec0a25314537a5a5d8529492047L70-R70) [[2]](diffhunk://#diff-1edb479ec892c5414101c9a1f73901e67e546ec0a25314537a5a5d8529492047R87-R116) [[3]](diffhunk://#diff-1edb479ec892c5414101c9a1f73901e67e546ec0a25314537a5a5d8529492047L110-R134) [[4]](diffhunk://#diff-1edb479ec892c5414101c9a1f73901e67e546ec0a25314537a5a5d8529492047R151-R152)
* Added a new test to assert that every `dotnet` command receives an explicit config file, increasing confidence in the change.

**Error handling:**
* Adjusted error assertions in tests to match the new command format with the `--configfile` argument.