### PR TITLE
fix(dotnet\coding-standards): input issue with roslyn analzyer

### DIFF
--- a/dotnet/coding-standards/analyzers/CodingStandards.Analyzers/CodingStandards.Analyzers.csproj
+++ b/dotnet/coding-standards/analyzers/CodingStandards.Analyzers/CodingStandards.Analyzers.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <PackageId>CodingStandards.Analyzers</PackageId>
     <AssemblyName>CodingStandards.Analyzers</AssemblyName>
     <IncludeBuildOutput>true</IncludeBuildOutput>

--- a/dotnet/coding-standards/analyzers/CodingStandards.Analyzers/Directory.Build.props
+++ b/dotnet/coding-standards/analyzers/CodingStandards.Analyzers/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <!-- This file intentionally exists to stop MSBuild from inheriting any
+       Directory.Build.props from parent directories (e.g. the consumer repository).
+       CodingStandards.Analyzers is fully self-contained and must not be affected
+       by consumer-level MSBuild customizations that could strip or conflict with
+       its package versions. -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/dotnet/coding-standards/analyzers/CodingStandards.Analyzers/Directory.Packages.props
+++ b/dotnet/coding-standards/analyzers/CodingStandards.Analyzers/Directory.Packages.props
@@ -1,0 +1,7 @@
+<Project>
+  <!-- Opt this project out of Central Package Management so inline Version= attributes in the .csproj are always respected,
+       regardless of whether the consumer solution has ManagePackageVersionsCentrally=true. -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/dotnet/coding-standards/copy-relevant-files.js
+++ b/dotnet/coding-standards/copy-relevant-files.js
@@ -67,7 +67,7 @@ function run() {
     const directory = process.env.INPUT_DIRECTORY || '';
     const codeAnalyzersName = process.env.INPUT_CODE_ANALYZERS_NAME;
     const sourceDir = process.env.INPUT_SOURCE_DIR;
-    const roslynVersion = process.env.INPUT_ROSLYN_VERSION || '';
+    const roslynVersion = (process.env.INPUT_ROSLYN_VERSION || '').trim();
     
     const root = parseFirstRoot(rawRoots, directory);
 

--- a/dotnet/coding-standards/copy-relevant-files.test.js
+++ b/dotnet/coding-standards/copy-relevant-files.test.js
@@ -261,3 +261,32 @@ test('run: no Roslyn override when input not provided', () => {
   assert.ok(/Version="4\.7\.0"/.test(destXml));
   assert.ok(!/Roslyn Version Override:/.test(r.out));
 });
+
+test('run: no Roslyn override when input is whitespace-only (prevents Version=" " corruption)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'copy-'));
+  const source = path.join(tmp, 'src');
+  const analyzers = path.join(source, 'analyzers', 'CodeStandards.Analyzers');
+  fs.mkdirSync(analyzers, { recursive: true });
+  fs.writeFileSync(path.join(source, '.editorconfig'), 'root=true\n');
+  const csprojPath = path.join(analyzers, 'CodeStandards.Analyzers.csproj');
+  fs.writeFileSync(csprojPath, `
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+  </ItemGroup>
+</Project>`);
+  const root = path.join(tmp, 'root');
+  const r = withEnv({
+    INPUT_UNIQUE_ROOT_DIRECTORIES: '["' + root.replace(/\\/g, '/') + '"]',
+    INPUT_DIRECTORY: root,
+    INPUT_CODE_ANALYZERS_NAME: 'CodeStandards.Analyzers',
+    INPUT_SOURCE_DIR: source,
+    INPUT_ROSLYN_VERSION: '  '
+  }, () => run());
+  const destCsproj = path.join(root, 'CodeStandards.Analyzers', 'CodeStandards.Analyzers.csproj');
+  const destXml = fs.readFileSync(destCsproj, 'utf8');
+  assert.ok(/Version="4\.7\.0"/.test(destXml), 'original version must be preserved');
+  assert.ok(!/Version=" "/.test(destXml), 'version must not be replaced with whitespace');
+  assert.ok(!/Roslyn Version Override:/.test(r.out), 'override must not be logged');
+});


### PR DESCRIPTION
This pull request makes targeted improvements to the `CodingStandards.Analyzers` project to ensure it remains self-contained and unaffected by external MSBuild or package version customizations. The main changes focus on explicitly opting out of Central Package Management and preventing inheritance of parent `Directory.Build.props` files, as well as a minor code robustness improvement.

**MSBuild and Package Management Isolation:**

* Added a `Directory.Build.props` file to ensure the analyzer project does not inherit MSBuild customizations from parent directories, maintaining self-contained builds.
* Added a `Directory.Packages.props` file to explicitly opt out of Central Package Management, so inline `Version=` attributes in the `.csproj` always take precedence.
* Removed the `ManagePackageVersionsCentrally` property from the `.csproj` file, as this is now handled via the new props files.

**Code Quality:**

* Updated `copy-relevant-files.js` to trim whitespace from the `INPUT_ROSLYN_VERSION` environment variable, making input handling more robust.