### PR TITLE
chore(fusion/generate-subgraph-artifact): replace uses statement

### DIFF
--- a/.github/actions/reusable-fusion-subgraph-workflow/action.yml
+++ b/.github/actions/reusable-fusion-subgraph-workflow/action.yml
@@ -79,9 +79,7 @@ runs:
   
     - name: Generate Fusion subgraph artifact
       id: generate
-      # todo: switch to a custom action that wraps the existing generate-subgraph-artifact action and also handles the GitHub release step, to avoid code duplication between this workflow and the demo workflow
-      # uses: Now-Micro/fusion/generate-subgraph-artifact@v1
-      uses: ./fusion/generate-subgraph-artifact
+      uses: Now-Micro/actions/fusion/generate-subgraph-artifact@v1
       with:
         artifact-version: ${{ inputs['artifact-version'] }}
         debug-mode: ${{ inputs['ci-debug-mode'] }}


### PR DESCRIPTION
This pull request updates the way the Fusion subgraph artifact is generated in the workflow configuration. The main change is switching from a local action to a shared remote GitHub Action, which will help reduce code duplication and improve maintainability.

**Workflow improvements:**

* Updated the `Generate Fusion subgraph artifact` step in `.github/actions/reusable-fusion-subgraph-workflow/action.yml` to use the shared remote action `Now-Micro/actions/fusion/generate-subgraph-artifact@v1` instead of the local implementation, addressing previous code duplication concerns.