### PR TITLE
fix: fusion subgraph artifact generation issues

### DIFF
--- a/.github/workflows/demo-fusion-subgraph.yml
+++ b/.github/workflows/demo-fusion-subgraph.yml
@@ -42,12 +42,12 @@ on:
                 description: "Directory used for intermediate schema files."
                 required: false
                 type: string
-                default: "src/demo/fusion/Reviews/schema"
+                default: "src/demo/fusion/Reviews"
             source-repo-url:
                 description: "Source repository URL embedded in the artifact metadata."
                 required: false
                 type: string
-                default: ""
+                default: "http://localhost:59092/graphql"
             subgraph-http-url:
                 description: "HTTP URL registered in the subgraph config."
                 required: false

--- a/.github/workflows/demo-fusion-subgraph.yml
+++ b/.github/workflows/demo-fusion-subgraph.yml
@@ -47,7 +47,7 @@ on:
                 description: "Source repository URL embedded in the artifact metadata."
                 required: false
                 type: string
-                default: "http://localhost:59092/graphql"
+                default: "https://github.com/Now-Micro/actions"
             subgraph-http-url:
                 description: "HTTP URL registered in the subgraph config."
                 required: false

--- a/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.js
+++ b/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.js
@@ -118,7 +118,7 @@ function run() {
   } else {
     dlog('Skipping -e flag for Fusion pack.');
   }
-  dlog('Packing Fusion subgraph artifact.');
+  dlog(`Running Fusion pack with args: ${JSON.stringify(packArgs)}`);
   runDotnet(packArgs, execOpts);
 
   // Write metadata JSON

--- a/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.js
+++ b/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.js
@@ -92,7 +92,12 @@ function run() {
   }
 
   // Write subgraph config JSON
-  const configContent = JSON.stringify({ subgraph: subgraphName });
+  const configContent = JSON.stringify({
+    subgraph: subgraphName,
+    http: {
+      baseAddress: subgraphHttpUrl,
+    },
+  });
   dlog(`Writing subgraph config: ${configPath}`);
   fs.writeFileSync(configPath, configContent + '\n');
   dlogFileContents(configPath, fs.readFileSync(configPath, 'utf8'));

--- a/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.test.js
+++ b/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.test.js
@@ -171,6 +171,19 @@ test('debug mode logs generated schema and config contents', () => {
   assert.match(stdout, /type Query/i);
 });
 
+test('debug mode logs fusion pack arguments', () => {
+  const tmp = makeTempDir();
+  const env = baseEnv(tmp, { INPUT_DEBUG_MODE: 'true' });
+
+  const { exitCode, stdout } = runWithEnv(env);
+
+  assert.strictEqual(exitCode, 0);
+  assert.match(stdout, /Running Fusion pack with args:/);
+  assert.match(stdout, /"fusion"/);
+  assert.match(stdout, /"subgraph"/);
+  assert.match(stdout, /"pack"/);
+});
+
 test('success: writes metadata JSON with correct fields', () => {
   const tmp = makeTempDir();
   const env = baseEnv(tmp, { INPUT_COMMIT_SHA: 'deadbeef', INPUT_SOURCE_REPO_URL: 'https://example.com/repo' });

--- a/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.test.js
+++ b/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.test.js
@@ -145,6 +145,7 @@ test('success: writes subgraph-config.json with correct content', () => {
   assert.ok(fs.existsSync(configPath), 'subgraph-config.json should be written');
   const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
   assert.strictEqual(parsed.subgraph, 'my-subgraph');
+  assert.deepStrictEqual(parsed.http, { baseAddress: 'http://localhost:4000' });
 });
 
 test('debug mode logs generated schema and config contents', () => {
@@ -166,6 +167,7 @@ test('debug mode logs generated schema and config contents', () => {
   assert.match(stdout, /Contents of .*schema\.graphql:/);
   assert.match(stdout, /Contents of .*subgraph-config\.json:/);
   assert.match(stdout, /"subgraph":"my-subgraph"/);
+  assert.match(stdout, /"http":\{"baseAddress":"http:\/\/localhost:4000"\}/);
   assert.match(stdout, /type Query/i);
 });
 


### PR DESCRIPTION
This pull request updates the Fusion subgraph artifact generation workflow to improve configuration and debugging information. The main changes include enhancing the subgraph config file with HTTP address details, improving debug logging, and updating tests to ensure these new behaviors are validated.

**Enhancements to subgraph configuration:**

* The generated `subgraph-config.json` now includes an `http` property with a `baseAddress` field, populated from the `subgraphHttpUrl` input. This provides downstream consumers with the HTTP endpoint for the subgraph.
* The default value for the `source-repo-url` input in the workflow YAML is now set to the repository URL, and the default schema directory is updated for clarity.

**Debugging and testing improvements:**

* Debug log output now includes the full arguments used for the Fusion pack operation, making troubleshooting easier.
* Tests are updated to check for the new `http.baseAddress` property in the config file and to validate that debug logs contain the correct information about the Fusion pack arguments and config contents. [[1]](diffhunk://#diff-2971a9884312b5769129d91c9cd32960d399eb133f27366d41b3388c88ae7d9fR148) [[2]](diffhunk://#diff-2971a9884312b5769129d91c9cd32960d399eb133f27366d41b3388c88ae7d9fR170-R186)