### PR TITLE
fix(reusable-fusion-subgraph.yml): no checkout

### DIFF
--- a/.github/actions/reusable-fusion-subgraph-workflow/action.yml
+++ b/.github/actions/reusable-fusion-subgraph-workflow/action.yml
@@ -62,16 +62,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Authorization Check
-      uses: Now-Micro/actions/authorize@v1
-      with:
-        debug-mode: ${{ inputs['ci-debug-mode'] }}
-
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      with:
-        fetch-depth: 0
-
     - name: Setup .NET SDK
       uses: Now-Micro/actions/dotnet/install@v1
       with:

--- a/.github/workflows/reusable-fusion-subgraph.yml
+++ b/.github/workflows/reusable-fusion-subgraph.yml
@@ -72,6 +72,11 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Check out code
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  fetch-depth: 0
+
             - name: Run reusable Fusion subgraph workflow
               uses: ./.github/actions/reusable-fusion-subgraph-workflow
               with:

--- a/.github/workflows/reusable-fusion-subgraph.yml
+++ b/.github/workflows/reusable-fusion-subgraph.yml
@@ -72,6 +72,11 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
+            - name: Authorization Check
+              uses: Now-Micro/actions/authorize@v1
+              with:
+                  debug-mode: ${{ inputs['ci-debug-mode'] }}
+
             - name: Check out code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by adding a step to check out the repository code before running the reusable Fusion subgraph workflow. This ensures that the workflow has access to the full codebase during execution.

* Added a `Check out code` step using the `actions/checkout` action with `fetch-depth: 0` to ensure the workflow has the complete repository history. (.github/workflows/reusable-fusion-subgraph.yml)