### PR TITLE
refactor(fusion\generate-subgraph-artifact): so that no project-path is required

### DIFF
--- a/.github/actions/reusable-fusion-subgraph-workflow/action.yml
+++ b/.github/actions/reusable-fusion-subgraph-workflow/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: ""
   project-path:
-    description: "Path to the .csproj file used to export the GraphQL schema. Relative to the repository root (or to working-directory when set)."
+    description: "Path to the .csproj file used to export the GraphQL schema. Relative to the repository root (or to working-directory when set). Leave empty only when schema.graphql has already been created under schema-dir; otherwise the action fails."
     required: false
   publish-dir:
     description: "Directory where the .fsp artifact and metadata JSON are written."

--- a/.github/actions/reusable-fusion-subgraph-workflow/action.yml
+++ b/.github/actions/reusable-fusion-subgraph-workflow/action.yml
@@ -27,7 +27,7 @@ inputs:
     default: ""
   project-path:
     description: "Path to the .csproj file used to export the GraphQL schema. Relative to the repository root (or to working-directory when set)."
-    required: true
+    required: false
   publish-dir:
     description: "Directory where the .fsp artifact and metadata JSON are written."
     required: false

--- a/.github/workflows/reusable-fusion-subgraph.yml
+++ b/.github/workflows/reusable-fusion-subgraph.yml
@@ -31,7 +31,7 @@ on:
                 type: string
                 default: ""
             project-path:
-                description: "Path to the .csproj file used to export the GraphQL schema. Relative to the repository root (or to working-directory when set)."
+                description: "Path to the .csproj file used to export the GraphQL schema. Relative to the repository root (or to working-directory when set). When omitted or empty, the workflow expects a pre-existing schema.graphql in schema-dir; if that file is missing, the job fails."
                 required: false
                 type: string
             publish-dir:

--- a/.github/workflows/reusable-fusion-subgraph.yml
+++ b/.github/workflows/reusable-fusion-subgraph.yml
@@ -32,7 +32,7 @@ on:
                 default: ""
             project-path:
                 description: "Path to the .csproj file used to export the GraphQL schema. Relative to the repository root (or to working-directory when set)."
-                required: true
+                required: false
                 type: string
             publish-dir:
                 description: "Directory where the .fsp artifact and metadata JSON are written."

--- a/fusion/generate-subgraph-artifact/action.yml
+++ b/fusion/generate-subgraph-artifact/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: "false"
   project-path:
-    description: "Path to the .csproj file used to export the GraphQL schema."
+    description: "Optional path to the .csproj file used to export the GraphQL schema. If omitted or empty, schema-dir/schema.graphql must already exist (pre-populated) or the action will fail."
     required: false
   publish-dir:
     description: "Directory where the .fsp artifact and metadata JSON are written."

--- a/fusion/generate-subgraph-artifact/action.yml
+++ b/fusion/generate-subgraph-artifact/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: "false"
   project-path:
     description: "Path to the .csproj file used to export the GraphQL schema."
-    required: true
+    required: false
   publish-dir:
     description: "Directory where the .fsp artifact and metadata JSON are written."
     required: true

--- a/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.js
+++ b/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.js
@@ -33,16 +33,16 @@ function runDotnet(args, execOpts) {
 function run() {
   debug = (process.env.INPUT_DEBUG_MODE || 'false').toLowerCase() === 'true';
 
-  const artifactVersion = process.env.INPUT_ARTIFACT_VERSION || '';
-  const commitSha       = process.env.INPUT_COMMIT_SHA       || process.env.GITHUB_SHA || '';
+  const artifactVersion = (process.env.INPUT_ARTIFACT_VERSION || '').trim();
+  const commitSha       = (process.env.INPUT_COMMIT_SHA || '').trim() || (process.env.GITHUB_SHA || '').trim();
   const githubOutput    = process.env.GITHUB_OUTPUT          || '';
-  const projectPath     = process.env.INPUT_PROJECT_PATH     || '';
-  const rawPublishDir   = process.env.INPUT_PUBLISH_DIR      || '';
-  const rawSchemaDir    = process.env.INPUT_SCHEMA_DIR       || '';
-  const sourceRepoUrl   = process.env.INPUT_SOURCE_REPO_URL  || '';
-  const subgraphHttpUrl = process.env.INPUT_SUBGRAPH_HTTP_URL || 'http://localhost:4000';
-  const subgraphName    = process.env.INPUT_SUBGRAPH_NAME    || '';
-  const workingDir      = process.env.INPUT_WORKING_DIRECTORY || '';
+  const projectPath     = (process.env.INPUT_PROJECT_PATH || '').trim();
+  const rawPublishDir   = (process.env.INPUT_PUBLISH_DIR || '').trim();
+  const rawSchemaDir    = (process.env.INPUT_SCHEMA_DIR || '').trim();
+  const sourceRepoUrl   = (process.env.INPUT_SOURCE_REPO_URL || '').trim();
+  const subgraphHttpUrl = (process.env.INPUT_SUBGRAPH_HTTP_URL || 'http://localhost:4000').trim() || 'http://localhost:4000';
+  const subgraphName    = (process.env.INPUT_SUBGRAPH_NAME || '').trim();
+  const workingDir      = (process.env.INPUT_WORKING_DIRECTORY || '').trim();
 
   if (!artifactVersion) exitWith('Input "artifact-version" is required.');
   if (!rawPublishDir)   exitWith('Input "publish-dir" is required.');

--- a/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.js
+++ b/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.js
@@ -33,22 +33,21 @@ function runDotnet(args, execOpts) {
 function run() {
   debug = (process.env.INPUT_DEBUG_MODE || 'false').toLowerCase() === 'true';
 
-  const projectPath     = process.env.INPUT_PROJECT_PATH     || '';
-  const rawSchemaDir    = process.env.INPUT_SCHEMA_DIR       || '';
-  const rawPublishDir   = process.env.INPUT_PUBLISH_DIR      || '';
-  const subgraphName    = process.env.INPUT_SUBGRAPH_NAME    || '';
   const artifactVersion = process.env.INPUT_ARTIFACT_VERSION || '';
   const commitSha       = process.env.INPUT_COMMIT_SHA       || process.env.GITHUB_SHA || '';
+  const githubOutput    = process.env.GITHUB_OUTPUT          || '';
+  const projectPath     = process.env.INPUT_PROJECT_PATH     || '';
+  const rawPublishDir   = process.env.INPUT_PUBLISH_DIR      || '';
+  const rawSchemaDir    = process.env.INPUT_SCHEMA_DIR       || '';
   const sourceRepoUrl   = process.env.INPUT_SOURCE_REPO_URL  || '';
   const subgraphHttpUrl = process.env.INPUT_SUBGRAPH_HTTP_URL || 'http://localhost:4000';
+  const subgraphName    = process.env.INPUT_SUBGRAPH_NAME    || '';
   const workingDir      = process.env.INPUT_WORKING_DIRECTORY || '';
-  const githubOutput    = process.env.GITHUB_OUTPUT          || '';
 
-  if (!projectPath)     exitWith('Input "project-path" is required.');
-  if (!rawSchemaDir)    exitWith('Input "schema-dir" is required.');
-  if (!rawPublishDir)   exitWith('Input "publish-dir" is required.');
-  if (!subgraphName)    exitWith('Input "subgraph-name" is required.');
   if (!artifactVersion) exitWith('Input "artifact-version" is required.');
+  if (!rawPublishDir)   exitWith('Input "publish-dir" is required.');
+  if (!rawSchemaDir)    exitWith('Input "schema-dir" is required.');
+  if (!subgraphName)    exitWith('Input "subgraph-name" is required.');
 
   const baseDir = workingDir ? path.resolve(workingDir) : process.cwd();
   const resolvedWorkingDir = workingDir ? path.resolve(workingDir) : '';
@@ -62,18 +61,18 @@ function run() {
   const artifactPath   = path.join(publishDir, `${subgraphName}.fsp`);
   const metadataPath   = path.join(publishDir, `${subgraphName}.metadata.json`);
 
-  dlog(`project-path:       ${projectPath}`);
-  dlog(`schema-dir:         ${schemaDir}`);
-  dlog(`publish-dir:        ${publishDir}`);
-  dlog(`subgraph-name:      ${subgraphName}`);
+  dlog(`artifact-path:      ${artifactPath}`);
   dlog(`artifact-version:   ${artifactVersion}`);
   dlog(`commit-sha:         ${commitSha}`);
+  dlog(`metadata-path:      ${metadataPath}`);
+  dlog(`project-path:       ${projectPath}`);
+  dlog(`publish-dir:        ${publishDir}`);
+  dlog(`schema-dir:         ${schemaDir}`);
+  dlog(`schema-path:        ${schemaPath}`);
   dlog(`source-repo-url:    ${sourceRepoUrl}`);
   dlog(`subgraph-http-url:  ${subgraphHttpUrl}`);
+  dlog(`subgraph-name:      ${subgraphName}`);
   dlog(`working-directory:  ${resolvedWorkingDir || '(default)'}`);
-  dlog(`schema-path:        ${schemaPath}`);
-  dlog(`artifact-path:      ${artifactPath}`);
-  dlog(`metadata-path:      ${metadataPath}`);
 
   // Create required directories
   dlog(`Creating directories: ${schemaDir}, ${publishDir}`);
@@ -86,7 +85,18 @@ function run() {
 
   // Export schema from the project
   dlog('Running dotnet schema export.');
-  runDotnet(['run', '--project', projectPath, '--', 'schema', 'export', '--output', schemaPath], execOpts);
+
+  if (projectPath) {
+    dlog(`Using project path: ${projectPath}`);
+    runDotnet(['run', '--project', projectPath, '--', 'schema', 'export', '--output', schemaPath], execOpts);
+  } else {
+    dlog('No project path provided, assuming schema is already present at schema path and skipping export step.');
+  }
+
+  if (!fs.existsSync(schemaPath)) {
+    exitWith(`Schema file not found at ${schemaPath}. Provide project-path or pre-populate schema.graphql in schema-dir.`);
+  }
+
   if (debug && fs.existsSync(schemaPath)) {
     dlogFileContents(schemaPath, fs.readFileSync(schemaPath, 'utf8'));
   }

--- a/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.test.js
+++ b/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.test.js
@@ -44,6 +44,11 @@ function runWithEnv(env, spawnStub = () => ({ status: 0 })) {
   const spawnCalls = [];
   cp.spawnSync = (cmd, args, opts) => {
     spawnCalls.push({ cmd: String(cmd), args: Array.isArray(args) ? [...args] : [], opts: { ...opts } });
+    if (cmd === 'dotnet' && Array.isArray(args) && args[0] === 'run' && args.includes('--output')) {
+      const outputPath = args[args.indexOf('--output') + 1];
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      fs.writeFileSync(outputPath, 'type Query { hello: String }\n');
+    }
     return spawnStub(cmd, args, opts);
   };
 
@@ -146,6 +151,32 @@ test('success: writes subgraph-config.json with correct content', () => {
   const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
   assert.strictEqual(parsed.subgraph, 'my-subgraph');
   assert.deepStrictEqual(parsed.http, { baseAddress: 'http://localhost:4000' });
+});
+
+test('success: no project-path works when schema.graphql is already present', () => {
+  const tmp = makeTempDir();
+  const env = baseEnv(tmp, { INPUT_PROJECT_PATH: '' });
+  fs.mkdirSync(env.INPUT_SCHEMA_DIR, { recursive: true });
+  fs.writeFileSync(path.join(env.INPUT_SCHEMA_DIR, 'schema.graphql'), 'type Query { hello: String }\n');
+
+  const { exitCode, spawnCalls } = runWithEnv(env);
+
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(spawnCalls.length, 3);
+  assert.deepStrictEqual(spawnCalls[0].args, ['tool', 'restore']);
+  assert.deepStrictEqual(spawnCalls[1].args, ['fusion', 'subgraph', 'config', 'set', 'http', '--url', 'http://localhost:4000', '-w', path.join(tmp, 'schema')]);
+  assert.deepStrictEqual(spawnCalls[2].args, ['fusion', 'subgraph', 'pack', '-s', path.join(tmp, 'schema', 'schema.graphql'), '-c', path.join(tmp, 'schema', 'subgraph-config.json'), '-p', path.join(tmp, 'publish', 'my-subgraph.fsp')]);
+});
+
+test('exits 1 when project-path is empty and schema.graphql is missing', () => {
+  const tmp = makeTempDir();
+  const env = baseEnv(tmp, { INPUT_PROJECT_PATH: '' });
+
+  const { exitCode, stderr } = runWithEnv(env);
+
+  assert.strictEqual(exitCode, 1);
+  assert.match(stderr, /schema file not found/i);
+  assert.match(stderr, /provide project-path/i);
 });
 
 test('debug mode logs generated schema and config contents', () => {
@@ -368,15 +399,6 @@ function escapeRegExp(value) {
 }
 
 // ─── missing required inputs ──────────────────────────────────────────────────
-
-test('exits 1 when project-path is missing', () => {
-  const tmp = makeTempDir();
-  const env = baseEnv(tmp);
-  delete env.INPUT_PROJECT_PATH;
-  const { exitCode, stderr } = runWithEnv(env);
-  assert.strictEqual(exitCode, 1);
-  assert.match(stderr, /project-path/i);
-});
 
 test('exits 1 when schema-dir is missing', () => {
   const tmp = makeTempDir();

--- a/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.test.js
+++ b/fusion/generate-subgraph-artifact/generate-fusion-subgraph-artifact.test.js
@@ -168,6 +168,28 @@ test('success: no project-path works when schema.graphql is already present', ()
   assert.deepStrictEqual(spawnCalls[2].args, ['fusion', 'subgraph', 'pack', '-s', path.join(tmp, 'schema', 'schema.graphql'), '-c', path.join(tmp, 'schema', 'subgraph-config.json'), '-p', path.join(tmp, 'publish', 'my-subgraph.fsp')]);
 });
 
+test('success: trims whitespace around project-path and directory inputs', () => {
+  const tmp = makeTempDir();
+  const env = baseEnv(tmp, {
+    INPUT_PROJECT_PATH: '   ',
+    INPUT_SCHEMA_DIR: '  schema  ',
+    INPUT_PUBLISH_DIR: '  publish  ',
+    INPUT_WORKING_DIRECTORY: tmp,
+  });
+
+  const schemaDir = path.join(tmp, 'schema');
+  fs.mkdirSync(schemaDir, { recursive: true });
+  fs.writeFileSync(path.join(schemaDir, 'schema.graphql'), 'type Query { hello: String }\n');
+
+  const { exitCode, spawnCalls } = runWithEnv(env);
+
+  assert.strictEqual(exitCode, 0);
+  assert.strictEqual(spawnCalls.length, 3);
+  assert.strictEqual(fs.existsSync(path.join(tmp, 'publish')), true);
+  assert.strictEqual(fs.existsSync(path.join(tmp, 'publish', 'my-subgraph.metadata.json')), true);
+  assert.ok(spawnCalls.every(call => call.opts.cwd === tmp), 'working-directory should still be respected');
+});
+
 test('exits 1 when project-path is empty and schema.graphql is missing', () => {
   const tmp = makeTempDir();
   const env = baseEnv(tmp, { INPUT_PROJECT_PATH: '' });


### PR DESCRIPTION
This pull request makes the `project-path` input optional in the Fusion subgraph artifact generation workflow and updates the implementation to allow artifact generation when a pre-existing `schema.graphql` file is present. It also improves error handling and test coverage for these scenarios.

**Workflow and Input Changes:**

* Made the `project-path` input optional in `.github/actions/reusable-fusion-subgraph-workflow/action.yml`, `fusion/generate-subgraph-artifact/action.yml`, and `.github/workflows/reusable-fusion-subgraph.yml`, allowing workflows to run without requiring a `.csproj` path. [[1]](diffhunk://#diff-db3d712219dcb9100c747a52851d7ff7f932f133beb3f7949076fef9d794f5f4L30-R30) [[2]](diffhunk://#diff-bda6f79d630840df6c8ab3e8ec1087dab5d0e5e1e18e5ecad84af0632115550dL18-R18) [[3]](diffhunk://#diff-315e504018bdb583d8f2c5c6202541987d837f131115fcf6beb799402ea006f2L35-R35)

**Implementation Updates:**

* Updated `generate-fusion-subgraph-artifact.js` to:
  - Skip schema export if `project-path` is not provided and instead use an existing schema file.
  - Add error handling to exit if neither `project-path` nor a schema file is available.
  - Reordered debug logging for clarity and added logs for new decision points. [[1]](diffhunk://#diff-f59efe8ba78c2378e09c3e2439a2a9a82c6af2015a432990b0136e8cf71ddf68L36-L51) [[2]](diffhunk://#diff-f59efe8ba78c2378e09c3e2439a2a9a82c6af2015a432990b0136e8cf71ddf68L65-L76) [[3]](diffhunk://#diff-f59efe8ba78c2378e09c3e2439a2a9a82c6af2015a432990b0136e8cf71ddf68R88-R99)

**Testing Improvements:**

* Enhanced tests in `generate-fusion-subgraph-artifact.test.js` to:
  - Cover cases where `project-path` is omitted and a schema file is present or missing.
  - Remove redundant tests now that `project-path` is optional.
  - Simulate schema file creation during mocked `dotnet` calls for more realistic test behavior. [[1]](diffhunk://#diff-2971a9884312b5769129d91c9cd32960d399eb133f27366d41b3388c88ae7d9fR47-R51) [[2]](diffhunk://#diff-2971a9884312b5769129d91c9cd32960d399eb133f27366d41b3388c88ae7d9fR156-R181) [[3]](diffhunk://#diff-2971a9884312b5769129d91c9cd32960d399eb133f27366d41b3388c88ae7d9fL372-L380)