### PR TITLE
refactor(github\release): to normalize the tag-name input

### DIFF
--- a/.github/actions/reusable-fusion-subgraph-workflow/action.yml
+++ b/.github/actions/reusable-fusion-subgraph-workflow/action.yml
@@ -107,7 +107,7 @@ runs:
         package-type: generic
         release-version: ${{ inputs['fusion-release-tag'] }}
         release-name-template: Fusion subgraph {library-name} {release-version}
-        tag-name: ${{ inputs['artifact-version'] }}
+        tag-name: ${{ inputs['fusion-release-tag'] }}-${{ inputs['artifact-version'] }}
         artifacts-path: ${{ inputs['publish-dir'] }}
         packages-path: release-assets
         skip-download: true

--- a/github/release/README.md
+++ b/github/release/README.md
@@ -15,11 +15,12 @@ Composite action that prepares release assets, builds release notes, and (option
 - `release-name-template` (default `{library-name} v{release-version}`): Template for release display name.
 - `release-version` (required): Version used in tag and release name.
 - `skip-download` (default `false`): When true, does not call `actions/download-artifact`.
-- `tag-prefix` (default `<library-name>-v`): Prefix concatenated with version to form the tag.
+- `tag-name` (optional): Override tag value. The action normalizes it to kebab-case before use, preserving a trailing semantic version when present.
+- `tag-prefix` (default `<library-name>-v`): Prefix concatenated with version to form the tag when `tag-name` is not provided.
 
 ## Outputs
 
-- `tag-name`: Computed tag (prefix + version).
+- `tag-name`: Computed tag after normalization/rewrite.
 - `release-name`: Rendered release name.
 - `release-notes-path`: Absolute path to generated notes.
 - `has-packages`: Count of copied packages.

--- a/github/release/action.yml
+++ b/github/release/action.yml
@@ -42,7 +42,7 @@ inputs:
     description: "Package type to release. Supported values: npm, nuget, or generic."
     required: true
   tag-name:
-    description: "Optional exact tag name. When set, overrides tag-prefix and release-version when building the git tag."
+    description: "Optional tag override. The value is normalized to kebab-case before use, with a trailing semantic version preserved, and overrides tag-prefix plus release-version when building the git tag."
     required: false
     default: ""
   release-name-template:

--- a/github/release/github-release.js
+++ b/github/release/github-release.js
@@ -229,14 +229,14 @@ function run() {
         const artifactsPath = path.resolve(process.env.INPUT_ARTIFACTS_PATH || 'release-artifacts');
         const packagesPath = path.resolve(process.env.INPUT_PACKAGES_PATH || 'release-packages');
         const changelogPath = (process.env.INPUT_CHANGELOG_PATH || '').trim();
-        const exactTagName = normalizeTagName(process.env.INPUT_TAG_NAME || '');
+        const normalizedTagName = normalizeTagName(process.env.INPUT_TAG_NAME || '');
         const tagPrefixInput = (process.env.INPUT_TAG_PREFIX || '').trim();
         const releaseNameTemplate = (process.env.INPUT_RELEASE_NAME_TEMPLATE || '{library-name} v{release-version}');
         const bodyFilename = (process.env.INPUT_BODY_FILENAME || 'RELEASE_NOTES.md').trim();
         const debugMode = parseBool(process.env.INPUT_DEBUG_MODE || 'false');
 
         const tagPrefix = tagPrefixInput || `${libraryName}-v`;
-        const tagName = exactTagName || `${tagPrefix}${releaseVersion}`;
+        const tagName = normalizedTagName || `${tagPrefix}${releaseVersion}`;
         const releaseName = releaseNameTemplate
             .replace('{library-name}', libraryName)
             .replace('{release-version}', releaseVersion);
@@ -247,7 +247,7 @@ function run() {
             console.log(`Debug: artifactsPath=${artifactsPath}`);
             console.log(`Debug: packagesPath=${packagesPath}`);
             console.log(`Debug: changelogPath=${changelogPath || '(none)'}`);
-            console.log(`Debug: exactTagName=${exactTagName || '(none)'}`);
+            console.log(`Debug: normalizedTagName=${normalizedTagName || '(none)'}`);
             console.log(`Debug: tagPrefix=${tagPrefix}`);
             console.log(`Debug: releaseNameTemplate=${releaseNameTemplate}`);
             console.log(`Debug: tagName=${tagName}`);

--- a/github/release/github-release.js
+++ b/github/release/github-release.js
@@ -32,6 +32,32 @@ function getPackageType() {
     return packageType;
 }
 
+function toKebabCase(value) {
+    return String(value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function normalizeTagName(value) {
+    const trimmed = String(value || '').trim().toLowerCase();
+    const semverMatch = trimmed.match(/^(.*?)(?:[\s._-]+)?(v?\d+\.\d+\.\d+(?:[-+][0-9a-z.-]+)?)$/i);
+
+    if (!semverMatch) {
+        return toKebabCase(trimmed);
+    }
+
+    const prefix = toKebabCase(semverMatch[1]);
+    const version = semverMatch[2].replace(/^v/, '');
+
+    if (!prefix) {
+        return version;
+    }
+
+    return `${prefix}-${version}`;
+}
+
 function safeMkdir(dir) {
     fs.mkdirSync(dir, { recursive: true });
 }
@@ -203,7 +229,7 @@ function run() {
         const artifactsPath = path.resolve(process.env.INPUT_ARTIFACTS_PATH || 'release-artifacts');
         const packagesPath = path.resolve(process.env.INPUT_PACKAGES_PATH || 'release-packages');
         const changelogPath = (process.env.INPUT_CHANGELOG_PATH || '').trim();
-        const exactTagName = (process.env.INPUT_TAG_NAME || '').trim();
+        const exactTagName = normalizeTagName(process.env.INPUT_TAG_NAME || '');
         const tagPrefixInput = (process.env.INPUT_TAG_PREFIX || '').trim();
         const releaseNameTemplate = (process.env.INPUT_RELEASE_NAME_TEMPLATE || '{library-name} v{release-version}');
         const bodyFilename = (process.env.INPUT_BODY_FILENAME || 'RELEASE_NOTES.md').trim();
@@ -276,4 +302,4 @@ if (require.main === module) {
     run();
 }
 
-module.exports = { run, copyPackages, listFilesRecursive, buildReleaseNotes, getPackageType };
+module.exports = { run, copyPackages, listFilesRecursive, buildReleaseNotes, getPackageType, toKebabCase, normalizeTagName };

--- a/github/release/github-release.test.js
+++ b/github/release/github-release.test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { run, copyPackages, buildReleaseNotes } = require('./github-release');
+const { run, copyPackages, buildReleaseNotes, toKebabCase, normalizeTagName } = require('./github-release');
 
 const ROOT_RELEASE_NOTES = path.join(process.cwd(), 'RELEASE_NOTES.md');
 
@@ -278,17 +278,30 @@ test('run honors exact tag-name override for generic release assets', () => {
         INPUT_PACKAGE_TYPE: 'generic',
         INPUT_ARTIFACTS_PATH: artifacts,
         INPUT_PACKAGES_PATH: packagesPath,
-        INPUT_TAG_NAME: 'Reviews-v1.2.3',
+        INPUT_TAG_NAME: 'Review Subgraph 1.2.3',
         INPUT_RELEASE_NAME_TEMPLATE: 'Fusion subgraph {library-name} {release-version}',
     });
 
     assert.strictEqual(r.exitCode, 0);
     const outputs = parseOutput(r.outputContent);
-    assert.strictEqual(outputs.tag_name, 'Reviews-v1.2.3');
+    assert.strictEqual(outputs.tag_name, 'review-subgraph-1.2.3');
     assert.strictEqual(outputs.has_packages, '2');
     assert.deepStrictEqual(JSON.parse(outputs.packages_json).sort(), ['Reviews.fsp', 'Reviews.metadata.json'].sort());
     assert.ok(fs.existsSync(path.join(packagesPath, 'Reviews.fsp')));
     assert.ok(fs.existsSync(path.join(packagesPath, 'Reviews.metadata.json')));
+});
+
+
+test('toKebabCase normalizes spaces and punctuation', () => {
+    assert.strictEqual(toKebabCase(' Review Subgraph 1.2.3 '), 'review-subgraph-1-2-3');
+    assert.strictEqual(toKebabCase('Already-kebab'), 'already-kebab');
+    assert.strictEqual(toKebabCase(''), '');
+});
+
+test('normalizeTagName preserves trailing semantic version', () => {
+    assert.strictEqual(normalizeTagName(' Review Subgraph 1.2.3 '), 'review-subgraph-1.2.3');
+    assert.strictEqual(normalizeTagName('Account Subgraph-2.0.0-beta.1'), 'account-subgraph-2.0.0-beta.1');
+    assert.strictEqual(normalizeTagName('Already-kebab'), 'already-kebab');
 });
 
 


### PR DESCRIPTION
This pull request improves the normalization and consistency of tag names used for release artifacts in the Fusion subgraph workflow. It introduces utility functions to standardize tag naming, updates the workflow to use these normalized tags, and adds comprehensive tests to ensure correctness.

**Tag normalization improvements:**

* Added `toKebabCase` and `normalizeTagName` utility functions in `github-release.js` to standardize tag names by converting them to kebab-case and ensuring semantic versioning is preserved.
* Updated the main release logic to use `normalizeTagName` for the `exactTagName` variable, ensuring all tags are consistently formatted.
* Modified the workflow YAML to compose the tag name from both `fusion-release-tag` and `artifact-version`, separated by a dash, for clearer versioning.

**Testing enhancements:**

* Added and updated tests in `github-release.test.js` to cover the new normalization logic for tag names, including edge cases for spaces, punctuation, and semantic versions.
* Exported the new utility functions for direct testing and use in other modules. [[1]](diffhunk://#diff-a62a643ab00603522edd80fc4834f79040a6596bdceff54c58b8dd72be6356d0L279-R305) [[2]](diffhunk://#diff-82020bd491f3d5fb08ff0763689f0d7f589224e43f114a9247a7348456d81f08L7-R7)