### PR TITLE
chore(reusable-fusion-subgraph.yml): update release version and release-name-template

### DIFF
--- a/.github/actions/reusable-fusion-subgraph-workflow/action.yml
+++ b/.github/actions/reusable-fusion-subgraph-workflow/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: "1"
   artifact-version:
-    description: "Version string embedded in the artifact metadata and used to name the uploaded artifact."
+    description: "Semantic version for the artifact and release. Used in the artifact metadata, upload name, and release title."
     required: true
   ci-debug-mode:
     description: "Enable verbose debug logging for the generate step."
@@ -18,7 +18,7 @@ inputs:
     required: false
     default: "9.0.x"
   fusion-release-tag:
-    description: "When non-empty, create a GitHub release with this tag and attach the artifact files. Leave empty to skip the release step."
+    description: "Human-readable label used as the release tag prefix. The final release tag is normalized from this value plus artifact-version. Leave empty to skip the release step."
     required: false
     default: ""
   github-token:
@@ -105,7 +105,7 @@ runs:
         github-token: ${{ inputs['github-token'] }}
         library-name: ${{ inputs['subgraph-name'] }}
         package-type: generic
-        release-version: ${{ inputs['fusion-release-tag'] }}
+        release-version: ${{ inputs['artifact-version'] }}
         release-name-template: Fusion subgraph {library-name} {release-version}
         tag-name: ${{ inputs['fusion-release-tag'] }}-${{ inputs['artifact-version'] }}
         artifacts-path: ${{ inputs['publish-dir'] }}

--- a/.github/workflows/reusable-fusion-subgraph.yml
+++ b/.github/workflows/reusable-fusion-subgraph.yml
@@ -12,7 +12,7 @@ on:
                 type: string
                 default: "1"
             artifact-version:
-                description: "Version string embedded in the artifact metadata and used to name the uploaded artifact."
+                description: "Semantic version for the artifact and release. Used in the artifact metadata, upload name, and release title."
                 required: true
                 type: string
             ci-debug-mode:
@@ -26,7 +26,7 @@ on:
                 type: string
                 default: "9.0.x"
             fusion-release-tag:
-                description: "When non-empty, create a GitHub release with this tag and attach the artifact files. Leave empty to skip the release step."
+                description: "Human-readable label used as the release tag prefix. The final release tag is normalized from this value plus artifact-version. Leave empty to skip the release step."
                 required: false
                 type: string
                 default: ""


### PR DESCRIPTION
This pull request updates the documentation and parameter handling for artifact and release versioning in the reusable Fusion subgraph workflow. The main focus is on clarifying the meaning and usage of the `artifact-version` and `fusion-release-tag` inputs, and ensuring consistent use of these parameters in the workflow and action files.

**Documentation and input improvements:**

* Updated the description of `artifact-version` to clarify that it is a semantic version used for the artifact, upload name, and release title in both `.github/actions/reusable-fusion-subgraph-workflow/action.yml` and `.github/workflows/reusable-fusion-subgraph.yml`. [[1]](diffhunk://#diff-db3d712219dcb9100c747a52851d7ff7f932f133beb3f7949076fef9d794f5f4L10-R10) [[2]](diffhunk://#diff-315e504018bdb583d8f2c5c6202541987d837f131115fcf6beb799402ea006f2L15-R15)
* Improved the description of `fusion-release-tag` to specify that it is a human-readable label used as the release tag prefix, with the final tag normalized from this value plus `artifact-version`, in both the action and workflow files. [[1]](diffhunk://#diff-db3d712219dcb9100c747a52851d7ff7f932f133beb3f7949076fef9d794f5f4L21-R21) [[2]](diffhunk://#diff-315e504018bdb583d8f2c5c6202541987d837f131115fcf6beb799402ea006f2L29-R29)

**Parameter usage consistency:**

* Changed the `release-version` parameter in the reusable action to use `artifact-version` instead of `fusion-release-tag`, ensuring the semantic version is used consistently for the release version.