### PR TITLE
chore(reusable-fusion-subgraph.yml): add v back to the release name template

### DIFF
--- a/.github/actions/reusable-fusion-subgraph-workflow/action.yml
+++ b/.github/actions/reusable-fusion-subgraph-workflow/action.yml
@@ -106,7 +106,7 @@ runs:
         library-name: ${{ inputs['subgraph-name'] }}
         package-type: generic
         release-version: ${{ inputs['artifact-version'] }}
-        release-name-template: Fusion subgraph {library-name} {release-version}
+        release-name-template: Fusion subgraph {library-name} v{release-version}
         tag-name: ${{ inputs['fusion-release-tag'] }}-${{ inputs['artifact-version'] }}
         artifacts-path: ${{ inputs['publish-dir'] }}
         packages-path: release-assets


### PR DESCRIPTION
This pull request makes a minor update to the release name template in the reusable Fusion subgraph workflow. The change adds a "v" prefix before the release version in the release name to standardize version formatting.

- Updated the `release-name-template` in `.github/actions/reusable-fusion-subgraph-workflow/action.yml` to include a "v" before the version number (e.g., `Fusion subgraph foo v1.2.3` instead of `Fusion subgraph foo 1.2.3`).