### PR TITLE
chore: clean up a bit and move dotnet and nuget source steps

### DIFF
--- a/.github/actions/demo-fusion-compose/action.yml
+++ b/.github/actions/demo-fusion-compose/action.yml
@@ -25,25 +25,15 @@ runs:
         echo "SUMMARY_FILE=$GITHUB_WORKSPACE/demo-fusion-compose-summary.txt" >> "$GITHUB_ENV"
         : > "$GITHUB_WORKSPACE/demo-fusion-compose-summary.txt"
 
-    - name: Install .NET SDK for Fusion compose
-      uses: ./dotnet/install
-      with:
-        dotnet-version: ${{ inputs.dotnet-version }}
-
-    - name: Configure GitHub NuGet sources
-      uses: ./nuget/configure-sources
-      with:
-        names: "Now-Micro, Trafera-LLC"
-        passwords: ${{ inputs.github-token }}
-        urls: "https://nuget.pkg.github.com/Now-Micro/index.json, https://nuget.pkg.github.com/trafera-LLC/index.json"
-        usernames: ${{ github.actor }}
-
     - name: Run fusion/compose with inline subgraph JSON
       id: compose
       uses: ./fusion/compose
       with:
         debug-mode: "true"
+        dotnet-version: ${{ inputs.dotnet-version }}
         gh-token: ${{ inputs.github-token }}
+        nuget-source-passwords: ${{ inputs.github-token }}
+        nuget-source-usernames: ${{ github.actor }}
         output-file: artifacts/gateway/gateway-placeholder.fgp
         subgraph-artifacts-json: |
           {
@@ -99,7 +89,7 @@ runs:
         mode: regex
         test-name: gateway sha256 is 64 hex chars
         summary-file: ${{ env.SUMMARY_FILE }}
-        
+
     - name: Publish summary
       if: always()
       shell: bash

--- a/fusion/compose/README.md
+++ b/fusion/compose/README.md
@@ -4,6 +4,7 @@ Restores Fusion subgraph artifacts from GitHub releases and composes them into a
 
 ## Inputs
 
+- `dotnet-version` (optional, default `8.0.x`): .NET SDK version installed before compose.
 - `debug-mode` (optional, default `false`): Enables verbose logging.
 - `dotnet-tools-manifest-path` (optional, default `.config/dotnet-tools.json`): Path to the local dotnet tools manifest.
 - `gh-token` (optional, default empty): GitHub token used for `gh release download`.
@@ -12,6 +13,10 @@ Restores Fusion subgraph artifacts from GitHub releases and composes them into a
 - `subgraph-artifacts-json` (optional, default empty): Inline JSON manifest for restore details. When provided, this overrides `manifest-path`.
 - `output-directory` (optional, default empty): Directory used for staged downloads. If empty, `manifest.outputDirectory` is used.
 - `output-file` (required): Output path for composed gateway file.
+- `nuget-source-names` (optional, default `Now-Micro, Trafera-LLC`): Comma-separated NuGet source names used by `nuget/configure-sources`.
+- `nuget-source-passwords` (optional, default empty): Comma-separated NuGet source passwords. Defaults to `gh-token` when empty.
+- `nuget-source-urls` (optional, default `https://nuget.pkg.github.com/Now-Micro/index.json, https://nuget.pkg.github.com/trafera-LLC/index.json`): Comma-separated NuGet source URLs.
+- `nuget-source-usernames` (optional, default empty): Comma-separated NuGet usernames. Defaults to `github.actor` when empty.
 - `run-dotnet-tool-restore` (optional, default `true`): Runs `dotnet tool restore` before compose.
 - `subgraph-file-extension` (optional, default `.fsp`): Extension used when discovering subgraph files.
 - `verify-fusion-command` (optional, default `true`): Runs `dotnet tool run fusion -- --help` before compose.

--- a/fusion/compose/TODOS.md
+++ b/fusion/compose/TODOS.md
@@ -1,6 +1,0 @@
-# TODOS
-
-- [x] Replace copied workflow with a composite action implementation.
-- [x] Convert shell logic to Node.js in a single runner file.
-- [x] Add unit tests covering success and failure paths.
-- [x] Remove legacy shell scripts.

--- a/fusion/compose/action.yml
+++ b/fusion/compose/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Path to the dotnet local tools manifest file."
     required: false
     default: ".config/dotnet-tools.json"
+  dotnet-version:
+    description: ".NET SDK version to install before running compose."
+    required: false
+    default: "8.0.x"
   gh-token:
     description: "GitHub token used by gh release download when restoring subgraph artifacts."
     required: false
@@ -33,6 +37,22 @@ inputs:
   output-file:
     description: "Destination path for the composed gateway .fgp file."
     required: true
+  nuget-source-names:
+    description: "Comma-separated NuGet source names passed to nuget/configure-sources."
+    required: false
+    default: "Now-Micro, Trafera-LLC"
+  nuget-source-passwords:
+    description: "Comma-separated NuGet source passwords. Defaults to gh-token when empty."
+    required: false
+    default: ""
+  nuget-source-urls:
+    description: "Comma-separated NuGet source URLs passed to nuget/configure-sources."
+    required: false
+    default: "https://nuget.pkg.github.com/Now-Micro/index.json, https://nuget.pkg.github.com/trafera-LLC/index.json"
+  nuget-source-usernames:
+    description: "Comma-separated NuGet source usernames. Defaults to github.actor when empty."
+    required: false
+    default: ""
   run-dotnet-tool-restore:
     description: "When true, run dotnet tool restore before composing."
     required: false
@@ -66,6 +86,19 @@ runs:
   steps:
     - name: Setup Node.js
       uses: Now-Micro/actions/setup-node@v1
+
+    - name: Install .NET SDK for Fusion compose
+      uses: Now-Micro/actions/dotnet/install@v1
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+
+    - name: Configure GitHub NuGet sources
+      uses: ./nuget/configure-sources
+      with:
+        names: ${{ inputs.nuget-source-names }}
+        passwords: ${{ inputs.nuget-source-passwords != '' && inputs.nuget-source-passwords || inputs.gh-token }}
+        urls: ${{ inputs.nuget-source-urls }}
+        usernames: ${{ inputs.nuget-source-usernames != '' && inputs.nuget-source-usernames || github.actor }}
 
     - name: Compose Fusion gateway
       id: compose

--- a/fusion/compose/action.yml
+++ b/fusion/compose/action.yml
@@ -84,17 +84,15 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Node.js
-      uses: Now-Micro/actions/setup-node@v1
-
     - name: Install .NET SDK for Fusion compose
       uses: Now-Micro/actions/dotnet/install@v1
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 
     - name: Configure GitHub NuGet sources
-      uses: ./nuget/configure-sources
+      uses: Now-Micro/actions/nuget/configure-sources@v1
       with:
+        debug-mode: ${{ inputs.debug-mode }}
         names: ${{ inputs.nuget-source-names }}
         passwords: ${{ inputs.nuget-source-passwords != '' && inputs.nuget-source-passwords || inputs.gh-token }}
         urls: ${{ inputs.nuget-source-urls }}


### PR DESCRIPTION
This pull request updates the Fusion Compose GitHub Action to improve configuration flexibility and simplify its usage. The main changes include adding new input parameters for NuGet source configuration and .NET SDK version selection, updating documentation, and cleaning up obsolete files.

**Enhancements to action configuration:**

* Added new input parameters to `fusion/compose/action.yml` for NuGet source names, passwords, URLs, usernames, and the .NET SDK version, allowing users to customize package source configuration and SDK selection. [[1]](diffhunk://#diff-c72b6614d32d60457022d870efc81fe5eb74620c8e32cfe38f797c2cbc135338R13-R16) [[2]](diffhunk://#diff-c72b6614d32d60457022d870efc81fe5eb74620c8e32cfe38f797c2cbc135338R40-R55)
* Updated the action’s workflow steps to install the specified .NET SDK and configure NuGet sources using the new inputs, replacing hardcoded values and improving flexibility. [[1]](diffhunk://#diff-c72b6614d32d60457022d870efc81fe5eb74620c8e32cfe38f797c2cbc135338R90-R102) [[2]](diffhunk://#diff-f2c652654036f740d9355939c8354b0bfff78dcf956661ff67f32c229adac35dL28-R36)

**Documentation updates:**

* Expanded `fusion/compose/README.md` to document the new input parameters and their defaults, making it easier for users to understand configuration options. [[1]](diffhunk://#diff-953912592b964d94fd26b2cdf52026c6b717580025b16dc86a3f88e296e555b2R7) [[2]](diffhunk://#diff-953912592b964d94fd26b2cdf52026c6b717580025b16dc86a3f88e296e555b2R16-R19)

**Cleanup:**

* Removed the obsolete `fusion/compose/TODOS.md` file, as all listed tasks have been completed.