### PR TITLE
fix: fusion artifact generation todo removal

### DIFF
--- a/.github/actions/reusable-fusion-subgraph-workflow/action.yml
+++ b/.github/actions/reusable-fusion-subgraph-workflow/action.yml
@@ -68,9 +68,7 @@ runs:
 
     - name: Generate Fusion subgraph artifact
       id: generate
-      uses: ./fusion/generate-subgraph-artifact
-      # TODO: Uncomment this when new version up
-      # uses: Now-Micro/actions/fusion/generate-subgraph-artifact@v1
+      uses: Now-Micro/actions/fusion/generate-subgraph-artifact@v1
       with:
         artifact-version: ${{ inputs['artifact-version'] }}
         debug-mode: ${{ inputs['ci-debug-mode'] }}


### PR DESCRIPTION
This pull request updates the workflow configuration to use the published version of the Fusion subgraph artifact generation action instead of a local path. This change simplifies maintenance and ensures that the workflow uses the latest version of the action.

**Workflow configuration update:**

* Updated the `Generate Fusion subgraph artifact` step in `.github/actions/reusable-fusion-subgraph-workflow/action.yml` to use the published action `Now-Micro/actions/fusion/generate-subgraph-artifact@v1` instead of the local path.