### PR TITLE
fix(fusion\compose): issue with extra files being present

### DIFF
--- a/fusion/compose/README.md
+++ b/fusion/compose/README.md
@@ -49,7 +49,7 @@ Manifest input is required. Provide it using either `manifest-path` or `subgraph
 }
 ```
 
-Each downloaded `assetName` is staged under `<outputDirectory>/<name>/` and copied to `<outputDirectory>/<name>/<name>.fsp` for stable composition inputs.
+Each downloaded `assetName` is staged under `<outputDirectory>/<name>/` and composed directly using that manifest-defined file name.
 
 When `gatewayFileName` is provided, it overrides the file name segment from `output-file` while keeping the same output directory.
 

--- a/fusion/compose/compose.js
+++ b/fusion/compose/compose.js
@@ -225,12 +225,6 @@ function restoreSubgraphArtifacts(options) {
     if (!fs.existsSync(downloadedAssetPath)) {
       exitWith(`Expected downloaded asset '${downloadedAssetPath}' was not found.`);
     }
-
-     const subgraphAssetExtension = path.extname(subgraphAssetName);
-     const stableAssetPath = path.join(stagingDirectory, `${subgraphName}${subgraphAssetExtension}`);
-    if (stableAssetPath !== downloadedAssetPath) {
-      fs.copyFileSync(downloadedAssetPath, stableAssetPath);
-    }
   }
 
   return {

--- a/fusion/compose/compose.test.js
+++ b/fusion/compose/compose.test.js
@@ -185,7 +185,7 @@ test('success: compose only writes output and outputs metadata', () => {
   assert.strictEqual(composeCall.args.filter(a => a === '-s').length, 2);
 });
 
-test('success: restore mode downloads assets and composes renamed .fsp files', () => {
+test('success: restore mode downloads assets and composes manifest-named .fsp files', () => {
   const root = makeTempDir();
   const env = createValidEnvironment(root, {
     INPUT_INPUT_DIRECTORY: 'artifacts/subgraphs',
@@ -219,8 +219,10 @@ test('success: restore mode downloads assets and composes renamed .fsp files', (
   assert.strictEqual(ghDownloadCalls.length, 2);
   assert.ok(ghDownloadCalls.every(c => c.options && c.options.env && c.options.env.GH_TOKEN === 'ghp_test'));
 
-  assert.ok(fs.existsSync(path.join(root, 'artifacts', 'subgraphs', 'accounts', 'accounts.fsp')));
-  assert.ok(fs.existsSync(path.join(root, 'artifacts', 'subgraphs', 'products', 'products.fsp')));
+  assert.ok(fs.existsSync(path.join(root, 'artifacts', 'subgraphs', 'accounts', 'accounts-release.fsp')));
+  assert.ok(fs.existsSync(path.join(root, 'artifacts', 'subgraphs', 'products', 'products-release.fsp')));
+  assert.ok(!fs.existsSync(path.join(root, 'artifacts', 'subgraphs', 'accounts', 'accounts.fsp')));
+  assert.ok(!fs.existsSync(path.join(root, 'artifacts', 'subgraphs', 'products', 'products.fsp')));
 });
 
 test('success: output-directory input overrides manifest outputDirectory', () => {
@@ -273,7 +275,8 @@ test('success: inline subgraph artifacts JSON overrides manifest file path', () 
     c => c.command === 'gh' && c.args[0] === 'release' && c.args[1] === 'download'
   );
   assert.strictEqual(ghDownloadCalls.length, 1);
-  assert.ok(fs.existsSync(path.join(root, 'inline', 'subgraphs', 'catalog', 'catalog.fsp')));
+  assert.ok(fs.existsSync(path.join(root, 'inline', 'subgraphs', 'catalog', 'catalog-release.fsp')));
+  assert.ok(!fs.existsSync(path.join(root, 'inline', 'subgraphs', 'catalog', 'catalog.fsp')));
 });
 
 test('success: manifest gatewayFileName overrides output-file name', () => {


### PR DESCRIPTION
This pull request updates how subgraph assets are handled during the restore and compose process, ensuring that assets are composed directly using their manifest-defined file names rather than being renamed to a stable name. The tests and documentation are updated accordingly to reflect this change.

**Asset handling improvements:**

* Assets are now composed directly using the manifest-defined file name instead of being copied to a stable `<name>.fsp` file in the staging directory. (`fusion/compose/compose.js`)
* Documentation updated to clarify that each downloaded asset is composed directly using the manifest-defined file name. (`fusion/compose/README.md`)

**Test updates:**

* Test names and assertions updated to expect manifest-named `.fsp` files (e.g., `accounts-release.fsp`) and to assert that the old stable-named files (e.g., `accounts.fsp`) do not exist. (`fusion/compose/compose.test.js`) [[1]](diffhunk://#diff-64fcdd1692855ddd8811b181e9d4fab1ac0c862f5b1c54d7773ad5547a10473cL188-R188) [[2]](diffhunk://#diff-64fcdd1692855ddd8811b181e9d4fab1ac0c862f5b1c54d7773ad5547a10473cL222-R225) [[3]](diffhunk://#diff-64fcdd1692855ddd8811b181e9d4fab1ac0c862f5b1c54d7773ad5547a10473cL276-R279)