### PR TITLE
chore(setup-node): add package-manager input

### DIFF
--- a/.github/actions/demo-setup-node/README.md
+++ b/.github/actions/demo-setup-node/README.md
@@ -1,0 +1,3 @@
+# Setup Node.js Demo
+
+Runs the `setup-node` composite action with npm, pnpm, and yarn. Each fixture installs dependencies and verifies that its configured package manager runs the test script.

--- a/.github/actions/demo-setup-node/action.yml
+++ b/.github/actions/demo-setup-node/action.yml
@@ -1,0 +1,44 @@
+name: Demo - Setup Node.js
+description: Demonstrates setup-node with npm, pnpm, and yarn.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup and test npm
+      uses: ./setup-node
+      with:
+        install-dependencies: "true"
+        install-dependencies-directory: .github/actions/demo-setup-node/npm
+        node-version: "22.x"
+        package-manager: npm
+
+    - name: Run npm case
+      shell: bash
+      working-directory: .github/actions/demo-setup-node/npm
+      run: npm test
+
+    - name: Setup and test pnpm
+      uses: ./setup-node
+      with:
+        install-dependencies: "true"
+        install-dependencies-directory: .github/actions/demo-setup-node/pnpm
+        node-version: "22.x"
+        package-manager: pnpm
+
+    - name: Run pnpm case
+      shell: bash
+      working-directory: .github/actions/demo-setup-node/pnpm
+      run: pnpm test
+
+    - name: Setup and test yarn
+      uses: ./setup-node
+      with:
+        install-dependencies: "true"
+        install-dependencies-directory: .github/actions/demo-setup-node/yarn
+        node-version: "22.x"
+        package-manager: yarn
+
+    - name: Run yarn case
+      shell: bash
+      working-directory: .github/actions/demo-setup-node/yarn
+      run: yarn test

--- a/.github/actions/demo-setup-node/npm/package.json
+++ b/.github/actions/demo-setup-node/npm/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "setup-node-demo-npm",
+    "private": true,
+    "scripts": {
+        "test": "node -e \"if (!process.env.npm_config_user_agent.startsWith('npm/')) process.exit(1)\""
+    }
+}

--- a/.github/actions/demo-setup-node/pnpm/package.json
+++ b/.github/actions/demo-setup-node/pnpm/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "setup-node-demo-pnpm",
+    "private": true,
+    "packageManager": "pnpm@9.15.0",
+    "scripts": {
+        "test": "node -e \"if (!process.env.npm_config_user_agent.startsWith('pnpm/')) process.exit(1)\""
+    }
+}

--- a/.github/actions/demo-setup-node/yarn/package.json
+++ b/.github/actions/demo-setup-node/yarn/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "setup-node-demo-yarn",
+    "private": true,
+    "packageManager": "yarn@1.22.22",
+    "scripts": {
+        "test": "node -e \"if (!process.env.npm_config_user_agent.startsWith('yarn/')) process.exit(1)\""
+    }
+}

--- a/.github/actions/run-demo-workflows/action.yml
+++ b/.github/actions/run-demo-workflows/action.yml
@@ -46,6 +46,9 @@ runs:
     - name: Demo - checks-workflow
       uses: ./.github/actions/demo-checks-workflow
 
+    - name: Demo - setup-node package managers
+      uses: ./.github/actions/demo-setup-node
+
     - name: Demo - pre-release-workflow
       uses: ./.github/actions/demo-pre-release-workflow
       with:

--- a/setup-node/README.md
+++ b/setup-node/README.md
@@ -1,6 +1,6 @@
 # Setup Node.js Environment
 
-This action installs the requested Node.js version, optionally enables npm caching, and can run a lockfile-aware npm install for you.
+This action installs the requested Node.js version, optionally enables package-manager caching, and can run a lockfile-aware dependency install for npm, pnpm, or yarn.
 
 ## Usage
 
@@ -13,7 +13,10 @@ This action installs the requested Node.js version, optionally enables npm cachi
     scope: '@now-micro'
     cache: true
     cache-dependency-path: package-lock.json
+    package-manager: npm
     install-dependencies: true
     install-dependencies-directory: src/demo/npm
     token-github-packages: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+  `package-manager` defaults to `npm`. Set it to `pnpm` or `yarn` to enable that package manager and use its lockfile-aware install command. The `cache` input uses the selected package manager's cache.

--- a/setup-node/README.md
+++ b/setup-node/README.md
@@ -19,4 +19,4 @@ This action installs the requested Node.js version, optionally enables package-m
     token-github-packages: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-  `package-manager` defaults to `npm`. Set it to `pnpm` or `yarn` to enable that package manager and use its lockfile-aware install command. The `cache` input uses the selected package manager's cache.
+  `package-manager` defaults to `npm`. Set it to `pnpm` or `yarn` to enable that package manager and use its lockfile-aware install command. When using `pnpm` or `yarn`, make sure `cache-dependency-path` points to `pnpm-lock.yaml` or `yarn.lock` respectively. The `cache` input uses the selected package manager's cache.

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -58,13 +58,7 @@ runs:
             ;;
         esac
 
-        if [[ "$PACKAGE_MANAGER" != "npm" ]]; then
-          if command -v corepack >/dev/null 2>&1; then
-            corepack enable "$PACKAGE_MANAGER"
-          elif ! command -v "$PACKAGE_MANAGER" >/dev/null 2>&1; then
-            npm install --global "$PACKAGE_MANAGER"
-          fi
-        fi
+        # Package manager enablement is handled after actions/setup-node so it uses the configured Node.js version.
 
     - name: Set up Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -115,8 +115,13 @@ runs:
             ;;
           yarn)
             if [[ -f yarn.lock ]]; then
-              echo "📦 Installing dependencies with yarn install --frozen-lockfile"
-              yarn install --frozen-lockfile
+              if yarn --help 2>&1 | grep -q -- '--immutable'; then
+                echo "📦 Installing dependencies with yarn install --immutable"
+                yarn install --immutable
+              else
+                echo "📦 Installing dependencies with yarn install --frozen-lockfile"
+                yarn install --frozen-lockfile
+              fi
             else
               echo "⚠️ No lockfile found; installing dependencies with yarn install"
               yarn install

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -2,51 +2,77 @@ name: Setup Node.js Environment
 description: Composite action to set up Node.js with caching for GitHub Actions workflows.
 inputs:
   cache:
-    description: 'Enable dependency caching (true/false)'
+    description: "Enable dependency caching (true/false)"
     required: false
-    default: 'false'
+    default: "false"
   cache-dependency-path:
-    description: 'Path to the dependency lock file for caching (e.g., package-lock.json)'
+    description: "Path to the dependency lock file for caching (e.g., package-lock.json)"
     required: false
   install-dependencies:
-    description: 'Install dependencies using npm ci (true/false)'
+    description: "Install dependencies using the selected package manager (true/false)"
     required: false
-    default: 'false'
+    default: "false"
   install-dependencies-directory:
-    description: 'Directory to run the dependency install in.'
+    description: "Directory to run the dependency install in."
     required: false
-    default: '.'
+    default: "."
   node-version:
-    description: 'The Node.js version to use'
+    description: "The Node.js version to use"
     required: false
-    default: '24.x'
+    default: "24.x"
+  package-manager:
+    description: "Package manager to use for caching and dependency installation (npm, pnpm, or yarn)"
+    required: false
+    default: "npm"
   registry-url:
-    description: 'npm registry URL to configure for package publication.'
+    description: "npm registry URL to configure for package publication."
     required: false
-    default: ''
+    default: ""
   scope:
-    description: 'npm scope to configure for the registry.'
+    description: "npm scope to configure for the registry."
     required: false
-    default: ''
+    default: ""
   show-version:
-    description: 'Show Node.js and npm version (true/false)'
+    description: "Show Node.js and npm version (true/false)"
     required: false
-    default: 'false'
+    default: "false"
   token-github-packages:
-    description: 'Token used to authenticate to the npm registry. Passed as NODE_AUTH_TOKEN.'
+    description: "Token used to authenticate to the npm registry. Passed as NODE_AUTH_TOKEN."
     required: false
-    default: ''
-  
+    default: ""
+
 runs:
   using: "composite"
   steps:
+    - name: Validate package manager
+      shell: bash
+      env:
+        PACKAGE_MANAGER: ${{ inputs['package-manager'] }}
+      run: |
+        case "$PACKAGE_MANAGER" in
+          npm|pnpm|yarn)
+            ;;
+          *)
+            echo "Unsupported package manager: '$PACKAGE_MANAGER'. Expected npm, pnpm, or yarn." >&2
+            exit 1
+            ;;
+        esac
+
+        if [[ "$PACKAGE_MANAGER" != "npm" ]]; then
+          if command -v corepack >/dev/null 2>&1; then
+            corepack enable "$PACKAGE_MANAGER"
+          elif ! command -v "$PACKAGE_MANAGER" >/dev/null 2>&1; then
+            npm install --global "$PACKAGE_MANAGER"
+          fi
+        fi
+
     - name: Set up Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       env:
         NODE_AUTH_TOKEN: ${{ inputs['token-github-packages'] }}
       with:
         cache-dependency-path: ${{ inputs.cache-dependency-path || '' }}
-        cache: ${{ inputs.cache == 'true' && 'npm' || '' }}
+        cache: ${{ inputs.cache == 'true' && inputs['package-manager'] || '' }}
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url || '' }}
         scope: ${{ inputs.scope || '' }}
@@ -57,14 +83,37 @@ runs:
       shell: bash
       env:
         NODE_AUTH_TOKEN: ${{ inputs['token-github-packages'] }}
+        PACKAGE_MANAGER: ${{ inputs['package-manager'] }}
       run: |
-        if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
-          echo "📦 Installing dependencies with npm ci"
-          npm ci
-        else
-          echo "⚠️ No lockfile found; installing dependencies with npm install --no-package-lock"
-          npm install --no-package-lock --no-audit --no-fund
-        fi
+        case "$PACKAGE_MANAGER" in
+          npm)
+            if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
+              echo "📦 Installing dependencies with npm ci"
+              npm ci
+            else
+              echo "⚠️ No lockfile found; installing dependencies with npm install --no-package-lock"
+              npm install --no-package-lock --no-audit --no-fund
+            fi
+            ;;
+          pnpm)
+            if [[ -f pnpm-lock.yaml ]]; then
+              echo "📦 Installing dependencies with pnpm install --frozen-lockfile"
+              pnpm install --frozen-lockfile
+            else
+              echo "⚠️ No lockfile found; installing dependencies with pnpm install --no-frozen-lockfile"
+              pnpm install --no-frozen-lockfile
+            fi
+            ;;
+          yarn)
+            if [[ -f yarn.lock ]]; then
+              echo "📦 Installing dependencies with yarn install --frozen-lockfile"
+              yarn install --frozen-lockfile
+            else
+              echo "⚠️ No lockfile found; installing dependencies with yarn install"
+              yarn install
+            fi
+            ;;
+        esac
 
     - name: Show Node.js and npm version
       shell: bash

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -85,6 +85,15 @@ runs:
         NODE_AUTH_TOKEN: ${{ inputs['token-github-packages'] }}
         PACKAGE_MANAGER: ${{ inputs['package-manager'] }}
       run: |
+        if [[ "$PACKAGE_MANAGER" != "npm" ]]; then
+          if command -v corepack >/dev/null 2>&1; then
+            corepack enable "$PACKAGE_MANAGER"
+          else
+            echo "corepack is required to use '$PACKAGE_MANAGER' with this action. Please use a Node.js version that includes corepack." >&2
+            exit 1
+          fi
+        fi
+
         case "$PACKAGE_MANAGER" in
           npm)
             if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then

--- a/setup-node/action.yml
+++ b/setup-node/action.yml
@@ -58,8 +58,6 @@ runs:
             ;;
         esac
 
-        # Package manager enablement is handled after actions/setup-node so it uses the configured Node.js version.
-
     - name: Set up Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       env:


### PR DESCRIPTION
This pull request extends the `setup-node` composite action to support multiple package managers (npm, pnpm, and yarn) for dependency installation and caching, instead of only npm. It introduces a new `package-manager` input, updates documentation, and ensures the correct installation commands and caching are used based on the selected package manager.

**Multi-package manager support:**

* Added a `package-manager` input to `action.yml`, allowing users to select between `npm`, `pnpm`, or `yarn` for dependency installation and caching. The input defaults to `npm` and is validated at runtime.
* Updated the dependency installation logic to use the appropriate commands and lockfiles for the selected package manager, including support for lockfile-aware installs for `pnpm` and `yarn`.
* Ensured that the `cache` input and cache logic use the selected package manager, not just npm.

**Documentation updates:**

* Updated `README.md` to describe support for `pnpm` and `yarn`, and documented the new `package-manager` input and its behavior. [[1]](diffhunk://#diff-93b13c381186a75bf0caaa8745668f94d700dd9d57fa2c5b50ad2d6e7b86da1dL3-R3) [[2]](diffhunk://#diff-93b13c381186a75bf0caaa8745668f94d700dd9d57fa2c5b50ad2d6e7b86da1dR16-R22)

**Other improvements:**

* Improved input descriptions and formatting in `action.yml` for clarity and consistency.