### PR TITLE
refactor(get-unique-project-directories): to handle different project types

### DIFF
--- a/get-unique-project-directories/README.md
+++ b/get-unique-project-directories/README.md
@@ -54,8 +54,11 @@ Values are de-duplicated in final output.
 
 ```yaml
 with:
+   # Match changed files under src or a top-level test directory and capture the project root.
    pattern: '^(src/[^/]+)/'
+   # Comma-separated source/test paths to resolve to project directories.
    paths: 'src/App/Program.cs,tests/App.Tests/Unit/Test1.cs'
+   # Serialize the unique directories as a JSON array.
    output-is-json: 'true'
 ```
 
@@ -63,8 +66,11 @@ with:
 
 ```yaml
 with:
+   # Select solution files as candidates for project-directory resolution.
    pattern: '.*\\.slnx$'
+   # Path to the changed solution file.
    paths: 'src/demo/get-unique-project-directories/Trafera.Messaging.slnx'
+   # Derive a fallback directory from the first path segment if no project file is found.
    fallback-regex: '^([^/]+)'
 ```
 
@@ -72,8 +78,11 @@ with:
 
 ```yaml
 with:
+   # Match source files whose output directory should be transformed.
    pattern: '^.*/src/.*\\.(cs|csproj|sln|slnx)$'
+   # Source file to resolve before applying the transformer.
    paths: 'src/My.Library/File.cs'
+   # Map the source project path to its corresponding tests project path.
    transformer: 's#^(.*?)/src/(.*)$#$1/tests/$2.Tests#'
 ```
 
@@ -81,9 +90,13 @@ with:
 
 ```yaml
 with:
+   # Match source C# files for project-directory resolution.
    pattern: '^.*/src/.*\\.cs$'
+   # Source file whose project path should be transformed.
    paths: 'src/My.Library/File.cs'
+   # Map the source project path to its tests project path.
    transformer: 's#^(.*?)/src/(.*)$#$1/tests/$2.Tests#'
+   # Keep the original project directory when the transformed directory is absent.
    use-original-if-missing: 'true'
 ```
 
@@ -91,8 +104,11 @@ with:
 
 ```yaml
 with:
+   # Match all C# files.
    pattern: '.*\\.cs$'
+   # Multiple paths can be supplied as a comma-separated list.
    paths: 'src/App/File1.cs,src/App/File2.cs'
+   # Return the unique directories as comma-separated text instead of JSON.
    output-is-json: 'false'
 ```
 
@@ -100,7 +116,10 @@ with:
 
 ```yaml
 with:
-   pattern: '\.(m?js|cjs|jsx|ts|tsx)$'
-   paths: 'packages/app/src/index.js,packages/lib/test/index.test.js'
+   # Match every supplied path so each one is checked for a nearby package.json.
+   pattern: '.*'
+   # Comma-separated directories or paths to inspect.
+   paths: 'packages/app/src,packages/lib/test'
+   # Use package.json to identify each Node.js project directory.
    project-file-name: 'package.json'
 ```

--- a/get-unique-project-directories/README.md
+++ b/get-unique-project-directories/README.md
@@ -1,12 +1,12 @@
 # get-unique-project-directories
 
-Returns unique parent project directories (nearest `.csproj` directory) from a list of input paths.
+Returns unique parent project directories (nearest matching project file, e.g. `.csproj` or `package.json`) from a list of input paths.
 
 For each path:
 
 - it first checks whether the path matches `pattern`
-- if matched, it walks up the tree to find the nearest `.csproj`
-- if found, it returns that `.csproj` directory
+- if matched, it walks up the tree to find the nearest file matching `project-file-name` (defaults to `.csproj`)
+- if found, it returns that project file's directory
 - if not found, it can optionally use `fallback-regex`
 - it can optionally transform output values with `transformer`
 - it can optionally fall back to original values when transformed directories do not exist (`use-original-if-missing`)
@@ -21,6 +21,9 @@ Values are de-duplicated in final output.
 - `paths` (required)  
    Comma-separated file path list to evaluate.
 
+- `project-file-name` (optional, default: `.csproj`)  
+   File name (or suffix) that identifies a project's root directory, matched case-insensitively via `endsWith`. Defaults to `.csproj` for .NET projects. Set to an exact file name such as `package.json` to locate Node.js project directories instead.
+
 - `output-is-json` (optional, default: `true`)  
   - `true`: output is JSON array string  
   - `false`: output is comma-separated string
@@ -29,7 +32,7 @@ Values are de-duplicated in final output.
    Enables debug logging.
 
 - `fallback-regex` (optional, default: empty)  
-   Applied only when no `.csproj` is found for a matched path.  
+   Applied only when no matching project file is found for a matched path.  
    If regex matches, capture group 1 is used; otherwise full match is used.
 
 - `transformer` (optional, default: empty)  
@@ -91,4 +94,13 @@ with:
    pattern: '.*\\.cs$'
    paths: 'src/App/File1.cs,src/App/File2.cs'
    output-is-json: 'false'
+```
+
+### 6) Find nearest Node.js project directory (`package.json`)
+
+```yaml
+with:
+   pattern: '\\.(m?js|cjs|jsx|ts|tsx)$'
+   paths: 'packages/app/src/index.js,packages/lib/test/index.test.js'
+   project-file-name: 'package.json'
 ```

--- a/get-unique-project-directories/README.md
+++ b/get-unique-project-directories/README.md
@@ -22,7 +22,7 @@ Values are de-duplicated in final output.
    Comma-separated file path list to evaluate.
 
 - `project-file-name` (optional, default: `.csproj`)  
-   File name (or suffix) that identifies a project's root directory, matched case-insensitively via `endsWith`. Defaults to `.csproj` for .NET projects. Set to an exact file name such as `package.json` to locate Node.js project directories instead.
+   File name (or suffix) that identifies a project's root directory, matched case-insensitively via `endsWith`. Leading and trailing whitespace is trimmed, whitespace-only values default to `.csproj`, and values containing `/` or `\\` are rejected. Set to an exact file name such as `package.json` to locate Node.js project directories instead.
 
 - `output-is-json` (optional, default: `true`)  
   - `true`: output is JSON array string  
@@ -100,7 +100,7 @@ with:
 
 ```yaml
 with:
-   pattern: '\\.(m?js|cjs|jsx|ts|tsx)$'
+   pattern: '\.(m?js|cjs|jsx|ts|tsx)$'
    paths: 'packages/app/src/index.js,packages/lib/test/index.test.js'
    project-file-name: 'package.json'
 ```

--- a/get-unique-project-directories/action.yml
+++ b/get-unique-project-directories/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
     default: "false"
   fallback-regex:
-    description: "Optional regex applied when no .csproj is found; if it matches, the first capture group (or full match) is used before directory flattening."
+    description: "Optional regex applied when no file matching project-file-name is found; if it matches, the first capture group (or full match) is used before directory flattening."
     required: false
     default: ""
   output-is-json:
@@ -21,7 +21,7 @@ inputs:
     description: "Comma-separated list of paths to evaluate."
     required: true
   project-file-name:
-    description: "File name (or suffix) that identifies a project's root directory, matched case-insensitively via endsWith. Defaults to '.csproj' when empty (see DEFAULT_PROJECT_FILE_NAME in get-unique-project-directories.js). Set to an exact file name such as 'package.json' to locate other manifest types."
+    description: "File name (or suffix) that identifies a project's root directory, matched case-insensitively via endsWith. Whitespace is trimmed, empty values use '.csproj', and path separators are rejected. Set to an exact file name such as 'package.json' to locate other manifest types."
     required: false
     default: ""
   transformer:

--- a/get-unique-project-directories/action.yml
+++ b/get-unique-project-directories/action.yml
@@ -1,5 +1,5 @@
 name: "Get Unique Project Directories"
-description: "Returns the unique parent project directories for the input paths based on a specified file pattern (e.g. .*.cs). Paths without a matching parent project file are omitted from the result. Optionally applies a fallback regex to extract a project name from the path when no parent project file is found, which can be useful for non-standard project structures."
+description: "Returns the unique parent project directories for the input paths based on a specified file pattern (e.g. .*.cs). Paths without a matching parent project file are omitted from the result. The parent project file to search for is configurable via project-file-name (defaults to .csproj), so it can also locate directories for other manifest types such as package.json. Optionally applies a fallback regex to extract a project name from the path when no parent project file is found, which can be useful for non-standard project structures."
 author: "Trafera"
 inputs:
   debug-mode:
@@ -15,11 +15,15 @@ inputs:
     required: false
     default: "true"
   pattern:
-    description: "Regular expression used to decide which file paths should be considered when searching for parent .csproj files."
+    description: "Regular expression used to decide which file paths should be considered when searching for parent project files."
     required: true
   paths:
     description: "Comma-separated list of paths to evaluate."
     required: true
+  project-file-name:
+    description: "File name (or suffix) that identifies a project's root directory, matched case-insensitively via endsWith. Defaults to '.csproj' when empty (see DEFAULT_PROJECT_FILE_NAME in get-unique-project-directories.js). Set to an exact file name such as 'package.json' to locate other manifest types."
+    required: false
+    default: ""
   transformer:
     description: "Optional output transformer. Supports either sed-style replacement (e.g. s#^src/#tests/#) or a regex extractor (first capture group, or full match). Applied to each resolved output path."
     required: false
@@ -35,7 +39,7 @@ inputs:
 
 outputs:
   unique_project_directories:
-    description: "Resolved parent project directories for each input path. Matched output paths are guaranteed to be unique. When matches come from actual project files, the directories will contain a .csproj; when derived via fallback-regex, they may instead reflect a regex-based project name without a corresponding .csproj."
+    description: "Resolved parent project directories for each input path. Matched output paths are guaranteed to be unique. When matches come from actual project files, the directories will contain a file matching project-file-name; when derived via fallback-regex, they may instead reflect a regex-based project name without a corresponding project file."
     value: ${{ steps.find-unique-project-directories.outputs.unique_project_directories }}
 
 runs:
@@ -54,6 +58,7 @@ runs:
         INPUT_FALLBACK_REGEX: ${{ inputs.fallback-regex }}
         INPUT_PATHS: ${{ inputs.paths }}
         INPUT_PATTERN: ${{ inputs.pattern }}
+        INPUT_PROJECT_FILE_NAME: ${{ inputs.project-file-name }}
         INPUT_TRANSFORMER: ${{ inputs.transformer }}
         INPUT_USE_ORIGINAL_IF_MISSING: ${{ inputs.use-original-if-missing }}
         INPUT_THROW_IF_TRANSFORMED_NOT_FOUND: ${{ inputs.throw-if-transformed-not-found }}

--- a/get-unique-project-directories/get-unique-project-directories.js
+++ b/get-unique-project-directories/get-unique-project-directories.js
@@ -12,6 +12,15 @@ function parseBool(val, def) {
     return def;
 }
 
+function normalizeProjectFileName(value) {
+    const normalized = String(value ?? '').trim();
+    if (!normalized) return DEFAULT_PROJECT_FILE_NAME;
+    if (/[\\/]/.test(normalized)) {
+        throw new Error('project-file-name must not contain path separators');
+    }
+    return normalized;
+}
+
 function normalizePath(input) {
     if (typeof input !== 'string') return '';
     const stripped = input.trim().replace(/['"\[\]]/g, '');
@@ -135,7 +144,13 @@ function run() {
     const pattern = process.env.INPUT_PATTERN;
     const debugMode = parseBool(process.env.INPUT_DEBUG_MODE, false);
     const outputIsJson = parseBool(process.env.INPUT_OUTPUT_IS_JSON, true);
-    const projectFileName = process.env.INPUT_PROJECT_FILE_NAME || DEFAULT_PROJECT_FILE_NAME;
+    let projectFileName;
+    try {
+        projectFileName = normalizeProjectFileName(process.env.INPUT_PROJECT_FILE_NAME);
+    } catch (error) {
+        console.error(`Invalid project file name: ${error.message}`);
+        process.exit(1);
+    }
     const useOriginalIfMissing = parseBool(process.env.INPUT_USE_ORIGINAL_IF_MISSING, false);
     const throwIfTransformedNotFound = parseBool(process.env.INPUT_THROW_IF_TRANSFORMED_NOT_FOUND, true);
     const fallbackRegexPattern = process.env.INPUT_FALLBACK_REGEX || '';
@@ -275,6 +290,7 @@ module.exports = {
     findNearestCsproj: findNearestProjectFile,
     normalizePath,
     parseBool,
+    normalizeProjectFileName,
     toDirectoryOnly,
     parseTransformer,
     transformOutputPath,

--- a/get-unique-project-directories/get-unique-project-directories.js
+++ b/get-unique-project-directories/get-unique-project-directories.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const CS_PROJ_EXTENSION = '.csproj';
+const DEFAULT_PROJECT_FILE_NAME = '.csproj';
 
 function parseBool(val, def) {
     if (val === undefined || val === null) return def;
@@ -73,7 +73,7 @@ function directoryExists(value) {
     }
 }
 
-function toDirectoryOnly(value) {
+function toDirectoryOnly(value, projectFileName = DEFAULT_PROJECT_FILE_NAME) {
     const normalized = normalizePath(value);
     if (!normalized) return '';
     if (!normalized.includes('/')) {
@@ -87,17 +87,18 @@ function toDirectoryOnly(value) {
         } catch (err) {
             // Ignore filesystem probing errors and fall back to heuristics.
         }
-        if (normalized.toLowerCase().endsWith(CS_PROJ_EXTENSION)) return '.';
+        if (normalized.toLowerCase().endsWith(projectFileName.toLowerCase())) return '.';
         return normalized;
     }
     const dir = path.posix.dirname(normalized);
     return normalizePath(dir);
 }
 
-function findNearestCsproj(inputPath) {
+function findNearestProjectFile(inputPath, projectFileName = DEFAULT_PROJECT_FILE_NAME) {
     const normalized = normalizePath(inputPath);
     if (!normalized) return '';
 
+    const target = projectFileName.toLowerCase();
     const absoluteFile = path.resolve(normalized);
     let currentDir;
     try {
@@ -111,7 +112,7 @@ function findNearestCsproj(inputPath) {
     while (true) {
         try {
             const entries = fs.readdirSync(currentDir, { withFileTypes: true });
-            const match = entries.find(entry => entry.isFile() && entry.name.toLowerCase().endsWith(CS_PROJ_EXTENSION));
+            const match = entries.find(entry => entry.isFile() && entry.name.toLowerCase().endsWith(target));
             if (match) {
                 const relative = path.relative(process.cwd(), path.join(currentDir, match.name));
                 return normalizePath(relative);
@@ -126,7 +127,7 @@ function findNearestCsproj(inputPath) {
         currentDir = parent;
     }
 
-    // No csproj found.
+    // No matching project file found.
     return '';
 }
 
@@ -134,6 +135,7 @@ function run() {
     const pattern = process.env.INPUT_PATTERN;
     const debugMode = parseBool(process.env.INPUT_DEBUG_MODE, false);
     const outputIsJson = parseBool(process.env.INPUT_OUTPUT_IS_JSON, true);
+    const projectFileName = process.env.INPUT_PROJECT_FILE_NAME || DEFAULT_PROJECT_FILE_NAME;
     const useOriginalIfMissing = parseBool(process.env.INPUT_USE_ORIGINAL_IF_MISSING, false);
     const throwIfTransformedNotFound = parseBool(process.env.INPUT_THROW_IF_TRANSFORMED_NOT_FOUND, true);
     const fallbackRegexPattern = process.env.INPUT_FALLBACK_REGEX || '';
@@ -149,6 +151,7 @@ function run() {
         console.log(`🔍 INPUT_PATTERN: ${pattern}`);
         console.log(`🔍 INPUT_PATHS: ${raw}`);
         console.log(`🔍 Cleaned paths: ${paths}`);
+        console.log(`🔍 PROJECT_FILE_NAME: ${projectFileName}`);
         console.log(`🔍 USE_ORIGINAL_IF_MISSING: ${useOriginalIfMissing}`);
         console.log(`🔍 THROW_IF_TRANSFORMED_NOT_FOUND: ${throwIfTransformedNotFound}`);
         if (fallbackRegexPattern) console.log(`🔍 FALLBACK_REGEX: ${fallbackRegexPattern}`);
@@ -197,10 +200,10 @@ function run() {
             if (debugMode) console.log(`🔍 Path '${p}' skipped; does not match pattern.`);
             continue;
         }
-        const resolved = findNearestCsproj(p);
+        const resolved = findNearestProjectFile(p, projectFileName);
         let candidate = resolved;
         let usedFallbackMatch = false;
-        if (!resolved.toLowerCase().endsWith(CS_PROJ_EXTENSION) && fallbackRe) {
+        if (!resolved.toLowerCase().endsWith(projectFileName.toLowerCase()) && fallbackRe) {
             const fallbackSource = resolved || p;
             const match = fallbackRe.exec(fallbackSource);
             if (match) {
@@ -221,7 +224,7 @@ function run() {
             continue;
         }
 
-        const finalValue = toDirectoryOnly(candidate);
+        const finalValue = toDirectoryOnly(candidate, projectFileName);
         const transformedValue = transformOutputPath(finalValue, transformer);
         let outputValue = transformedValue;
         const transformedMissing = transformer && transformedValue && !directoryExists(transformedValue);
@@ -266,4 +269,14 @@ function run() {
 }
 
 if (require.main === module) run();
-module.exports = { run, findNearestCsproj, normalizePath, parseBool, toDirectoryOnly, parseTransformer, transformOutputPath, directoryExists };
+module.exports = {
+    run,
+    findNearestProjectFile,
+    findNearestCsproj: findNearestProjectFile,
+    normalizePath,
+    parseBool,
+    toDirectoryOnly,
+    parseTransformer,
+    transformOutputPath,
+    directoryExists,
+};

--- a/get-unique-project-directories/get-unique-project-directories.test.js
+++ b/get-unique-project-directories/get-unique-project-directories.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { run, findNearestCsproj, normalizePath, parseBool, toDirectoryOnly, parseTransformer, transformOutputPath, directoryExists } = require('./get-unique-project-directories');
+const { run, findNearestCsproj, normalizePath, parseBool, normalizeProjectFileName, toDirectoryOnly, parseTransformer, transformOutputPath, directoryExists } = require('./get-unique-project-directories');
 
 function withEnv(env, fn) {
     const prev = { ...process.env };
@@ -143,6 +143,27 @@ test('project-file-name defaults to .csproj when not provided', () => {
         assert.strictEqual(r.exitCode, 0);
         assert.match(r.outputContent, /unique_project_directories=\["Messaging\/Trafera\.Messaging\.Abstractions\/src"\]/);
     });
+});
+
+test('project-file-name trims whitespace and defaults whitespace-only values', () => {
+    assert.strictEqual(normalizeProjectFileName('  package.json  '), 'package.json');
+    assert.strictEqual(normalizeProjectFileName('   '), '.csproj');
+});
+
+test('project-file-name rejects path separators', () => {
+    for (const value of ['packages/package.json', 'packages\\package.json']) {
+        assert.throws(() => normalizeProjectFileName(value), /must not contain path separators/);
+    }
+});
+
+test('invalid project-file-name exits 1', () => {
+    const r = runWith({
+        INPUT_PATTERN: '.*',
+        INPUT_PATHS: 'file.js',
+        INPUT_PROJECT_FILE_NAME: 'packages/package.json',
+    });
+    assert.strictEqual(r.exitCode, 1);
+    assert.match(r.err + r.out, /Invalid project file name/);
 });
 
 test('returns no entry when no csproj exists anywhere', () => {

--- a/get-unique-project-directories/get-unique-project-directories.test.js
+++ b/get-unique-project-directories/get-unique-project-directories.test.js
@@ -86,6 +86,65 @@ test('finds csproj in parent directory when nested', () => {
     });
 });
 
+test('project-file-name finds package.json in same directory (returns directory)', () => {
+    withTmpTree(() => {
+        touch('packages/app/package.json');
+        touch('packages/app/src/index.js');
+    }, () => {
+        const paths = 'packages/app/src/index.js';
+        const r = runWith({
+            INPUT_PATTERN: '\\.js$',
+            INPUT_PATHS: paths,
+            INPUT_PROJECT_FILE_NAME: 'package.json',
+        });
+        assert.strictEqual(r.exitCode, 0);
+        assert.match(r.outputContent, /unique_project_directories=\["packages\/app"\]/);
+    });
+});
+
+test('project-file-name finds package.json in parent directory when nested', () => {
+    withTmpTree(() => {
+        touch('packages/app/package.json');
+        touch('packages/app/test/sub/index.test.js');
+    }, () => {
+        const paths = 'packages/app/test/sub/index.test.js';
+        const r = runWith({
+            INPUT_PATTERN: '\\.js$',
+            INPUT_PATHS: paths,
+            INPUT_PROJECT_FILE_NAME: 'package.json',
+        });
+        assert.strictEqual(r.exitCode, 0);
+        assert.match(r.outputContent, /unique_project_directories=\["packages\/app"\]/);
+    });
+});
+
+test('project-file-name returns no entry when package.json does not exist anywhere', () => {
+    withTmpTree(() => {
+        touch('packages/app/README.md');
+    }, () => {
+        const paths = 'packages/app/README.md';
+        const r = runWith({
+            INPUT_PATTERN: '.*',
+            INPUT_PATHS: paths,
+            INPUT_PROJECT_FILE_NAME: 'package.json',
+        });
+        assert.strictEqual(r.exitCode, 0);
+        assert.match(r.outputContent, /unique_project_directories=\[\]/);
+    });
+});
+
+test('project-file-name defaults to .csproj when not provided', () => {
+    withTmpTree(() => {
+        touch('Messaging/Trafera.Messaging.Abstractions/src/Trafera.Messaging.Abstractions.csproj');
+        touch('Messaging/Trafera.Messaging.Abstractions/src/SomeFile.cs');
+    }, () => {
+        const paths = 'Messaging/Trafera.Messaging.Abstractions/src/SomeFile.cs';
+        const r = runWith({ INPUT_PATTERN: '.*\\.cs$', INPUT_PATHS: paths });
+        assert.strictEqual(r.exitCode, 0);
+        assert.match(r.outputContent, /unique_project_directories=\["Messaging\/Trafera\.Messaging\.Abstractions\/src"\]/);
+    });
+});
+
 test('returns no entry when no csproj exists anywhere', () => {
     withTmpTree(() => {
         touch('Messaging/Trafera.Messaging.Project3/README.md');


### PR DESCRIPTION
This pull request enhances the `get-unique-project-directories` action to support locating project directories based on configurable project manifest files, not just `.csproj`. The action now accepts a `project-file-name` input, allowing it to find directories for other project types (like Node.js projects with `package.json`). Documentation, implementation, and tests have all been updated to reflect this more flexible behavior.

**Key changes:**

**Feature enhancement: Configurable project file matching**
- Added a new `project-file-name` input (defaulting to `.csproj`) to allow searching for any project manifest file, such as `package.json`, instead of being limited to `.csproj`. The search is case-insensitive and uses `endsWith` matching. [[1]](diffhunk://#diff-7c07fe9c5c4416507ba4b5777611f4a62483724a00ad6eb173a2f4b05ebcf619L18-R26) [[2]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L4-R4) [[3]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L90-R101) [[4]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L114-R115) [[5]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L200-R206)
- Updated the main logic to use `findNearestProjectFile` instead of the previous `findNearestCsproj`, generalizing the search for project files. [[1]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L90-R101) [[2]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L114-R115) [[3]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L200-R206) [[4]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L269-R282)

**Documentation updates**
- Revised `README.md` and `action.yml` to describe the new `project-file-name` option, provide usage examples for non-.NET projects, and clarify output descriptions. [[1]](diffhunk://#diff-b7377dfaf2f9595b8f5ea2e73a057539f167e49453b17ced8a773435eddb28d8L3-R9) [[2]](diffhunk://#diff-b7377dfaf2f9595b8f5ea2e73a057539f167e49453b17ced8a773435eddb28d8R24-R26) [[3]](diffhunk://#diff-b7377dfaf2f9595b8f5ea2e73a057539f167e49453b17ced8a773435eddb28d8L32-R35) [[4]](diffhunk://#diff-b7377dfaf2f9595b8f5ea2e73a057539f167e49453b17ced8a773435eddb28d8R98-R106) [[5]](diffhunk://#diff-7c07fe9c5c4416507ba4b5777611f4a62483724a00ad6eb173a2f4b05ebcf619L2-R2) [[6]](diffhunk://#diff-7c07fe9c5c4416507ba4b5777611f4a62483724a00ad6eb173a2f4b05ebcf619L38-R42)

**Testing improvements**
- Added new tests to verify correct behavior when using `project-file-name` for `package.json`, including cases where the file exists at various directory levels or does not exist at all. Also tested default behavior when `project-file-name` is omitted.

**Internal refactoring**
- Renamed constants and function names to be more generic (e.g., `DEFAULT_PROJECT_FILE_NAME`, `findNearestProjectFile`) and updated all references accordingly. [[1]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L4-R4) [[2]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L90-R101) [[3]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L269-R282)
- Passed `projectFileName` through all relevant function calls and environment variables to support the new configurability. [[1]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L76-R76) [[2]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L129-R138) [[3]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662L224-R227) [[4]](diffhunk://#diff-47cf27e861bcea9fa387a78b90df875723027382c09cd74873c15f8e31045662R154) [[5]](diffhunk://#diff-7c07fe9c5c4416507ba4b5777611f4a62483724a00ad6eb173a2f4b05ebcf619R61)

These changes make the action much more flexible and applicable to a wider range of project types, while maintaining backward compatibility for .NET projects.