### PR TITLE
chore(reusable-checks.yml): add node-testing-path-pattern

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -135,7 +135,8 @@ Runs the repo's shared PR checks: linting, coding standards, and tests. It is de
 | `test-project-regex` | No | `""` | Regex used to identify the test project file. |
 | `solution-regex` | No | `""` | Regex used to identify the solution file. |
 | `prefer-solution` | No | `false` | Prefer a solution file over individual projects for testing. |
-| `node-test-directory` | No | `""` | Specific Node.js project directory to test. When empty, changed directories are detected automatically by locating the nearest `package.json` for each changed file (source/test file changes, `package.json` changes, and the lockfile matching `node-package-manager` all trigger detection). |
+| `node-test-directory` | No | `""` | Specific Node.js project directory to test. When empty, changed directories are detected automatically by locating the nearest `package.json` for each changed file. |
+| `node-testing-path-pattern` | No |'\.(m?js|cjs|jsx|ts|tsx)\$|(^|/)package\.json\$|(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)\$' | Regex used to identify changed Node.js files. Extend this for additional project files, such as VitePress `.vue`, `.md`, or `.mdx` files. |
 | `node-test-command` | No | `npm test` | Command to run for each Node.js project directory. |
 | `node-version` | No | `22.x` | Node.js version to use for Node.js tests. |
 | `node-package-manager` | No | `npm` | Package manager to use for Node.js tests and dependency installation. Supported values are `npm`, `pnpm`, and `yarn`. |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -136,7 +136,7 @@ Runs the repo's shared PR checks: linting, coding standards, and tests. It is de
 | `solution-regex` | No | `""` | Regex used to identify the solution file. |
 | `prefer-solution` | No | `false` | Prefer a solution file over individual projects for testing. |
 | `node-test-directory` | No | `""` | Specific Node.js project directory to test. When empty, changed directories are detected automatically by locating the nearest `package.json` for each changed file. |
-| `node-testing-path-pattern` | No |'\.(m?js|cjs|jsx|ts|tsx)\$|(^|/)package\.json\$|(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)\$' | Regex used to identify changed Node.js files. Extend this for additional project files, such as VitePress `.vue`, `.md`, or `.mdx` files. |
+| `node-testing-path-pattern` | No | `\.(m?js|cjs|jsx|ts|tsx)$|(^|/)package\.json$|(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$` | Regex used to identify changed Node.js files. Extend this for additional project files, such as VitePress `.vue`, `.md`, or `.mdx` files. |
 | `node-test-command` | No | `npm test` | Command to run for each Node.js project directory. |
 | `node-version` | No | `22.x` | Node.js version to use for Node.js tests. |
 | `node-package-manager` | No | `npm` | Package manager to use for Node.js tests and dependency installation. Supported values are `npm`, `pnpm`, and `yarn`. |

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -181,6 +181,13 @@ on:
                 required: false
                 type: string
                 default: ""
+            node-testing-path-pattern:
+                description:
+                    "Regex used to identify changed Node.js files. Defaults to
+                    JavaScript, package.json, and npm, pnpm, or yarn lockfiles."
+                required: false
+                type: string
+                default: '\.(m?js|cjs|jsx|ts|tsx)\$|(^|/)package\.json\$|(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)\$'
             node-test-command:
                 description:
                     "Command to run for each Node.js project directory. Defaults to
@@ -416,20 +423,6 @@ jobs:
                   head-ref: ${{ inputs['head-ref'] || github.sha }}
                   base-ref: ${{ github.event.repository.default_branch }}
 
-            - name: Determine Node.js change-detection pattern
-              if: ${{ steps.mode.outputs.mode == 'changes' }}
-              id: pattern
-              shell: bash
-              env:
-                  PACKAGE_MANAGER: ${{ inputs['node-package-manager'] }}
-              run: |
-                  case "$PACKAGE_MANAGER" in
-                    pnpm) lockfile='pnpm-lock\.yaml' ;;
-                    yarn) lockfile='yarn\.lock' ;;
-                    *) lockfile='package-lock\.json' ;;
-                  esac
-                  echo "pattern=\\.(m?js|cjs|jsx|ts|tsx)\$|(^|/)package\\.json\$|(^|/)${lockfile}\$" >> "$GITHUB_OUTPUT"
-
             - name: Get Unique Node.js Project Directories
               if: ${{ steps.mode.outputs.mode == 'changes' }}
               id: unique-dirs
@@ -437,7 +430,7 @@ jobs:
               with:
                   paths: ${{ inputs['overridden-changed-files'] ||
                       steps.changed-files.outputs.changed_files }}
-                  pattern: ${{ steps.pattern.outputs.pattern }}
+                  pattern: ${{ inputs['node-testing-path-pattern'] }}
                   project-file-name: "package.json"
                   debug-mode: ${{ inputs['ci-debug-mode'] }}
 

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -187,7 +187,7 @@ on:
                     JavaScript, package.json, and npm, pnpm, or yarn lockfiles."
                 required: false
                 type: string
-                default: '\.(m?js|cjs|jsx|ts|tsx)\$|(^|/)package\.json\$|(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)\$'
+                default: '\.(m?js|cjs|jsx|ts|tsx)$|(^|/)package\.json$|(^|/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$'
             node-test-command:
                 description:
                     "Command to run for each Node.js project directory. Defaults to


### PR DESCRIPTION
This pull request updates the configuration for Node.js project detection in the reusable GitHub workflow, making the process more flexible and easier to customize. The main change is the introduction of a new `node-testing-path-pattern` input, which allows users to specify a regex for detecting relevant Node.js files, replacing the previous logic that auto-selected patterns based on the package manager.

**Workflow configuration improvements:**

* Added a new `node-testing-path-pattern` input to `.github/workflows/reusable-checks.yml`, allowing users to customize the regex used to identify changed Node.js files. This input has a sensible default covering common JavaScript, TypeScript, and lockfiles.
* Updated the documentation in `.github/workflows/README.md` to describe the new `node-testing-path-pattern` input and its usage, including examples for extending it to other file types.

**Simplification of change-detection logic:**

* Removed the step that dynamically generated the Node.js change-detection pattern based on the selected package manager. The workflow now directly uses the `node-testing-path-pattern` input, simplifying the logic and making it more transparent.
* Updated the step that determines unique Node.js project directories to use the new `node-testing-path-pattern` input instead of the previously computed pattern output.