### PR TITLE
refactor(reusable-checks.yml): node-test-setup to mirror the existing test-setup job

### DIFF
--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -400,7 +400,7 @@ jobs:
                   TOKEN: ${{ secrets['token-github-packages'] }}
               run: |
                   if [ -z "$TOKEN" ]; then
-                    echo "::error::The 'token-github-packages' secret is required when 'enable-coding-standards' or 'enable-testing' is true, but it was not provided or is empty." >&2
+                    echo "::error::The 'token-github-packages' secret is required, but it was not provided or is empty." >&2
                     exit 1
                   fi
                   echo "✅ token-github-packages secret is present."

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -434,7 +434,7 @@ jobs:
                   pattern: ${{ inputs['node-testing-path-pattern'] }}
                   project-file-name: "package.json"
                   transformer: ${{ inputs.transformer }}
-                  use-original-if-missing: "false"
+                  use-original-if-missing: ${{ inputs['use-original-if-missing'] }}
 
             - name: Resolve Node.js test directories
               id: resolve-directories

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -394,18 +394,29 @@ jobs:
         outputs:
             directories_to_test: ${{ steps.resolve-directories.outputs.directories_to_test }}
         steps:
+            - name: Validate token-github-packages secret
+              shell: bash
+              env:
+                  TOKEN: ${{ secrets['token-github-packages'] }}
+              run: |
+                  if [ -z "$TOKEN" ]; then
+                    echo "::error::The 'token-github-packages' secret is required when 'enable-coding-standards' or 'enable-testing' is true, but it was not provided or is empty." >&2
+                    exit 1
+                  fi
+                  echo "✅ token-github-packages secret is present."
+
             - name: Check out code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
                   fetch-depth: 0
 
-            - name: Determine Node.js test mode
+            - name: Determine test mode
               id: mode
               shell: bash
               env:
                   DIRECTORY: ${{ inputs['node-test-directory'] }}
               run: |
-                  echo "Node.js test directory input: '$DIRECTORY'"
+                  echo "Directory input: '$DIRECTORY'"
                   if [ -n "$DIRECTORY" ]; then
                     echo "mode=directory" >> "$GITHUB_OUTPUT"
                     echo "directory=$DIRECTORY" >> "$GITHUB_OUTPUT"
@@ -413,6 +424,61 @@ jobs:
                   fi
 
                   echo "mode=changes" >> "$GITHUB_OUTPUT"
+
+            - name: Find Last Successful Checks Run on Branch
+              id: last-success
+              if:
+                  ${{ inputs['optimize-base-ref'] == 'true' && inputs['workflow-name'] != ''
+                  && inputs['caller-job-name'] != '' }}
+              uses: Now-Micro/actions/get-last-workflow-success-sha@v1
+              with:
+                  branch: ${{ github.head_ref }}
+                  debug-mode: ${{ inputs['ci-debug-mode'] }}
+                  default-branch: ${{ github.event.repository.default_branch }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  job-names-that-must-succeed:
+                      ${{ inputs['caller-job-name'] != '' && format('{0}
+                      / test', inputs['caller-job-name']) || 'test' }}
+                  main-job-name:
+                      ${{ inputs['caller-job-name'] != '' && format('{0} / test-setup',
+                      inputs['caller-job-name']) || 'test-setup' }}
+                  request-size: 50
+                  retry-attempts: 3
+                  workflow-name: ${{ inputs['workflow-name'] }}
+
+            - name: Get Changed Files Between Last Successful Run and Head
+              if: ${{ steps.mode.outputs.mode == 'changes' &&
+                  inputs['overridden-changed-files'] == '' }}
+              id: changed-files-against-last-success
+              uses: Now-Micro/actions/get-changed-files@v1
+              with:
+                  head-ref: ${{ inputs['head-ref'] || github.sha }}
+                  base-ref: ${{ steps.last-success.outputs.last_success_sha ||
+                      github.event.repository.default_branch }}
+
+            - name: Get Changed Files Between Default Branch and Head
+              if: ${{ steps.mode.outputs.mode == 'changes' &&
+                  inputs['overridden-changed-files'] == '' &&
+                  steps.last-success.outputs.last_success_sha != '' }}
+              id: changed-files-against-main
+              uses: Now-Micro/actions/get-changed-files@v1
+              with:
+                  head-ref: ${{ inputs['head-ref'] || github.sha }}
+                  base-ref: ${{ github.event.repository.default_branch }}
+
+            - name:
+                  Calculate Intersection of Changed Files (still changed since last
+                  successful run)
+              id: changed-files-to-use
+              if: ${{ steps.mode.outputs.mode == 'changes' &&
+                  inputs['overridden-changed-files'] == '' &&
+                  steps.last-success.outputs.last_success_sha != '' }}
+              uses: Now-Micro/actions/compare-json-arrays@v1
+              with:
+                  array-a: ${{ steps.changed-files-against-last-success.outputs.changed_files }}
+                  array-b: ${{ steps.changed-files-against-main.outputs.changed_files }}
+                  debug-mode: ${{ inputs['ci-debug-mode'] }}
+                  mode: "intersection"
 
             - name: Get Changed Files
               if: ${{ steps.mode.outputs.mode == 'changes' &&
@@ -423,20 +489,23 @@ jobs:
                   head-ref: ${{ inputs['head-ref'] || github.sha }}
                   base-ref: ${{ github.event.repository.default_branch }}
 
-            - name: Get Unique Node.js Project Directories
+            - name: Get Unique Project Directories
               if: ${{ steps.mode.outputs.mode == 'changes' }}
               id: unique-dirs
               uses: Now-Micro/actions/get-unique-project-directories@v1
               with:
                   debug-mode: ${{ inputs['ci-debug-mode'] }}
+                  fallback-regex: ${{ inputs['node-testing-path-pattern'] }}
                   paths: ${{ inputs['overridden-changed-files'] ||
-                      steps.changed-files.outputs.changed_files }}
+                      steps.changed-files-to-use.outputs.result ||
+                      steps.changed-files-against-last-success.outputs.changed_files
+                      }}
                   pattern: ${{ inputs['node-testing-path-pattern'] }}
                   project-file-name: "package.json"
                   transformer: ${{ inputs.transformer }}
                   use-original-if-missing: ${{ inputs['use-original-if-missing'] }}
 
-            - name: Resolve Node.js test directories
+            - name: Resolve test directories
               id: resolve-directories
               shell: bash
               env:

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -577,7 +577,7 @@ jobs:
                   TOKEN: ${{ secrets['token-github-packages'] }}
               run: |
                   if [ -z "$TOKEN" ]; then
-                    echo "::error::The 'token-github-packages' secret is required when 'enable-coding-standards' or 'enable-testing' is true, but it was not provided or is empty." >&2
+                    echo "::error::The 'token-github-packages' secret is required, but it was not provided or is empty." >&2
                     exit 1
                   fi
                   echo "✅ token-github-packages secret is present."

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -428,11 +428,13 @@ jobs:
               id: unique-dirs
               uses: Now-Micro/actions/get-unique-project-directories@v1
               with:
+                  debug-mode: ${{ inputs['ci-debug-mode'] }}
                   paths: ${{ inputs['overridden-changed-files'] ||
                       steps.changed-files.outputs.changed_files }}
                   pattern: ${{ inputs['node-testing-path-pattern'] }}
                   project-file-name: "package.json"
-                  debug-mode: ${{ inputs['ci-debug-mode'] }}
+                  transformer: ${{ inputs.transformer }}
+                  use-original-if-missing: "false"
 
             - name: Resolve Node.js test directories
               id: resolve-directories

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -440,8 +440,8 @@ jobs:
                       ${{ inputs['caller-job-name'] != '' && format('{0}
                       / test', inputs['caller-job-name']) || 'test' }}
                   main-job-name:
-                      ${{ inputs['caller-job-name'] != '' && format('{0} / test-setup',
-                      inputs['caller-job-name']) || 'test-setup' }}
+                      ${{ inputs['caller-job-name'] != '' && format('{0} / node-test-setup',
+                      inputs['caller-job-name']) || 'node-test-setup' }}
                   request-size: 50
                   retry-attempts: 3
                   workflow-name: ${{ inputs['workflow-name'] }}

--- a/.github/workflows/reusable-checks.yml
+++ b/.github/workflows/reusable-checks.yml
@@ -394,17 +394,6 @@ jobs:
         outputs:
             directories_to_test: ${{ steps.resolve-directories.outputs.directories_to_test }}
         steps:
-            - name: Validate token-github-packages secret
-              shell: bash
-              env:
-                  TOKEN: ${{ secrets['token-github-packages'] }}
-              run: |
-                  if [ -z "$TOKEN" ]; then
-                    echo "::error::The 'token-github-packages' secret is required, but it was not provided or is empty." >&2
-                    exit 1
-                  fi
-                  echo "✅ token-github-packages secret is present."
-
             - name: Check out code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:


### PR DESCRIPTION
This pull request updates the configuration for the `get-unique-project-directories` GitHub Action in the `.github/workflows/reusable-checks.yml` workflow. The main changes involve reordering and adding inputs to improve flexibility and control over how unique project directories are determined.

**Enhancements to Action Inputs:**

* Added the `transformer` input to allow custom transformation logic when determining project directories.
* Set `use-original-if-missing` to `"false"` to ensure only transformed results are used when a transformer is provided.
* Moved the `debug-mode` input to appear before other inputs for better readability and consistency.